### PR TITLE
Drop DEPOT_PATH assumption

### DIFF
--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -1307,7 +1307,7 @@ function buildstartupscript(user::String, custom_environment::Bool)
         cmd *= """
         
         sudo su - $user <<EOF
-        cd $(DEPOT_PATH[1])/environments/v$(VERSION.major).$(VERSION.minor)
+        cd /home/$user/.julia/environments/v$(VERSION.major).$(VERSION.minor)
         git fetch
         git checkout $environmentname
         julia -e 'using Pkg; pkg"instantiate"; pkg"precompile"'


### PR DESCRIPTION
However, this replaces the assumption that the depot path is the same at
the call-site as on the scale-set vm with the assumption that the scale-set
vm has its depot path at the default location: /home/$user/.julia.  In addition,
this keeps the assumption that the vm and the caller use the same julia
version (major and minor).