### PR TITLE
detachat macro does work in modules

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,6 +96,22 @@ end
     rmproc(testvm; session=session)
 end
 
+@testset "AzManagers, detachat, eval in modules" begin
+    r = randstring('a':'z',4)
+    basename = "test$r"
+    testvm = addproc(templatename; basename=basename, session=session)
+    job1 = @detachat testvm begin
+        write(stdout, "module $(@__MODULE__)\n")
+    end
+    wait(job1)
+    job2 = @detachat testvm begin
+        write(stdout, "module $(@__MODULE__)\n")
+    end
+    wait(job2)
+    @test read(job1) != read(job2)
+    rmproc(testvm; session=session)
+end
+
 @testset "AzManagers, detach" for kwargs in ( (dummy="dummy"), )
 
     #
@@ -109,7 +125,7 @@ end
     #
     # Unit Test 2 - Send a new job to the server started above
     #
-    job2 = @detachat job1.vm["ip"] begin
+    job2 = @detachat job1.vm begin
         write(stdout, "job2 - stdout string")
         write(stderr, "job2 - stderr string")
     end


### PR DESCRIPTION
Previous to this change, each invocation of `@detachat` would evaluate the code in `Main`.  I think that this change gives each call to `detachat` its own sandbox, rather than allowing invocations to share state.  I think that allowing shared state is confusing, and hence this change.