### PR TITLE
Use the current environment

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,8 @@ MPI = "0.14, 0.15, 0.16"
 julia = "^1.4"
 
 [extras]
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["TOML", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ AzSessions = "1"
 HTTP = "0.8, 0.9"
 JSON = "0.21"
 MPI = "0.14, 0.15, 0.16"
-julia = "1"
+julia = "^1.4"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -161,9 +161,9 @@ VM via a mix of MPI and OpenMP.
 # Custom environments
 AzManagers can create an on-the-fly custom Julia software environment for the workers.
 This is managed via Julia environments.  If you update your Julia environment, then
-you can, commit those updates to a branch and push that branch to a remote.  Subsequently, 
-when you create a cluster, the worker nodes will, at boot time, instantiate the environment.
-For example:
+you can, commit those updates to a branch and push that branch to a remote.
+Subsequently, when you create a cluster, the worker nodes will, at boot time, instantiate the
+environment. For example:
 ```sh
 julia -e `using Pkg; pkg"add FFTW"`
 cd /home/cvx/.julia/environments/v1.5
@@ -176,3 +176,10 @@ git push origin custom_environment
 Now, when worker VMs are initialized, they will have the software stack
 defined in `custom_environment`.  Please note that this can add significant
 overhead to the boot-time of the VMs.
+
+However, there are two subtleties to keep in mind.  The first is that the specific
+environment that is instantiated on the workers will be determined by the current
+project.  The second is that if the branch-name is equal to the name of the image,
+then the environment will not propagate to the workers.  This may change in a future
+release, but the reason for this behavior is to provide a convenient mechanism to
+minimize the time that it takes to start a worker.

--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -846,7 +846,8 @@ function scaleset_image(manager::AzManager, template, sigimagename, sigimagevers
 end
 
 function software_sanity_check(manager, imagename)
-    envpath = joinpath(DEPOT_PATH[1], "environments", "v$(VERSION.major).$(VERSION.minor)")
+    projectinfo = Pkg.project()
+    envpath = normpath(joinpath(projectinfo.path, ".."))
     local repo
     try
         repo = LibGit2.GitRepo(envpath)
@@ -916,24 +917,30 @@ function buildstartupscript(manager::AzManager, user::String, disk::AbstractStri
         """
     end
 
+    remote_julia_environment_name = ""
     if custom_environment
         try
-            environmentfolder = joinpath(DEPOT_PATH[1], "environments", "v$(VERSION.major).$(VERSION.minor)")
-            repo = LibGit2.GitRepo(environmentfolder)
+            projectinfo = Pkg.project()
+            julia_environment_folder = normpath(joinpath(projectinfo.path, ".."))
+            repo = LibGit2.GitRepo(julia_environment_folder)
             LibGit2.fetch(repo)
             remoteurl = LibGit2.fetchheads(repo)[1].url
             environmentname = LibGit2.branch(repo)
 
+            #=
+            There is no guarantee that `julia_environment_folder` will exist on the worker.
+            Therefore, we will put the environment into a sub-folder of Pkg.envdir().
+            =#
+            remote_julia_environment_name = splitpath(julia_environment_folder)[end]
+
             cmd *= """
             
             sudo su - $user <<'EOF'
-            JDPATH=`julia -e 'write(stdout, DEPOT_PATH[1])'`
-            JMAJOR=`julia -e 'write(stdout, string(VERSION.major))'`
-            JMINOR=`julia -e 'write(stdout, string(VERSION.minor))'`
-            cd \${JDPATH}/environments
-            rm -rf v\${JMAJOR}.\${JMINOR}
-            git clone -b $environmentname $remoteurl v\${JMAJOR}.\${JMINOR}
-            julia -e 'using Pkg; pkg"instantiate"; pkg"precompile"'
+            JULIA_ENVIRONMENT_FOLDER=`julia -e 'using Pkg; write(stdout, joinpath(Pkg.envdir(), "$remote_julia_environment_name"))'`
+            mkdir -p \${JULIA_ENVIRONMENT_FOLDER}
+            rm -rf \${JULIA_ENVIRONMENT_FOLDER}
+            git clone -b $environmentname $remoteurl \${JULIA_ENVIRONMENT_FOLDER}
+            julia -e 'using Pkg; path=joinpath(Pkg.envdir(), "$remote_julia_environment_name"); Pkg.activate(path); Pkg.instantiate(); Pkg.precompile()'
             touch /tmp/julia_instantiate_done
             EOF
             """
@@ -943,7 +950,7 @@ function buildstartupscript(manager::AzManager, user::String, disk::AbstractStri
         end
     end
 
-    cmd
+    cmd, remote_julia_environment_name
 end
 
 function build_envstring(env::Dict)
@@ -956,13 +963,15 @@ end
 
 function buildstartupscript_cluster(manager::AzManager, ppi::Int, mpi_ranks_per_worker::Int, mpi_flags, julia_num_threads::Int, omp_num_threads::Int, env::Dict, user::String,
         disk::AbstractString, custom_environment::Bool)
-    cmd = buildstartupscript(manager, user, disk, custom_environment)
+    cmd, remote_julia_environment_name = buildstartupscript(manager, user, disk, custom_environment)
 
     cookie = Distributed.cluster_cookie()
     master_address = string(getipaddr())
     master_port = manager.port
 
     envstring = build_envstring(env)
+
+    juliaenvstring = remote_julia_environment_name == "" ? "" : """; using Pkg; Pkg.activate(joinpath(Pkg.envdir(), "$remote_julia_environment_name")); Pkg.instantiate(); """
 
     if mpi_ranks_per_worker == 0
         cmd *= """
@@ -971,7 +980,7 @@ function buildstartupscript_cluster(manager::AzManager, ppi::Int, mpi_ranks_per_
         export JULIA_NUM_THREADS=$julia_num_threads
         export OMP_NUM_THREADS=$omp_num_threads
         $envstring
-        julia -e 'using AzManagers; AzManagers.azure_worker("$cookie", "$master_address", $master_port, $ppi)'
+        julia -e '$(juliaenvstring)using AzManagers; AzManagers.azure_worker("$cookie", "$master_address", $master_port, $ppi)'
         EOF
         """
     else
@@ -981,7 +990,7 @@ function buildstartupscript_cluster(manager::AzManager, ppi::Int, mpi_ranks_per_
         export JULIA_NUM_THREADS=$julia_num_threads
         export OMP_NUM_THREADS=$omp_num_threads
         $envstring
-        mpirun -n $mpi_ranks_per_worker $mpi_flags julia -e 'using AzManagers, MPI; AzManagers.azure_worker_mpi("$cookie", "$master_address", $master_port, $ppi)'
+        mpirun -n $mpi_ranks_per_worker $mpi_flags julia -e '$(juliaenvstring)using AzManagers, MPI; AzManagers.azure_worker_mpi("$cookie", "$master_address", $master_port, $ppi)'
         EOF
         """
     end
@@ -991,9 +1000,11 @@ end
 
 function buildstartupscript_detached(manager::AzManager, julia_num_threads::Int, omp_num_threads::Int, env::Dict, user::String,
         disk::AbstractString, custom_environment::Bool, subscriptionid, resourcegroup, vmname)
-    cmd = buildstartupscript(manager, user, disk, custom_environment)
+    cmd, remote_julia_environment_name = buildstartupscript(manager, user, disk, custom_environment)
 
     envstring = build_envstring(env)
+
+    juliaenvstring = remote_julia_environment_name == "" ? "" : """; using Pkg; Pkg.activate(joinpath(Pkg.envdir(), "$remote_julia_environment_name")); Pkg.instantiate(); """
 
     cmd *= """
 
@@ -1003,7 +1014,7 @@ function buildstartupscript_detached(manager::AzManager, julia_num_threads::Int,
     export OMP_NUM_THREADS=$omp_num_threads
     ssh-keygen -f /home/$user/.ssh/azmanagers_rsa -N '' <<<y
     cd /home/$user
-    julia -e 'using AzManagers; AzManagers.detachedservice(;subscriptionid="$subscriptionid", resourcegroup="$resourcegroup", vmname="$vmname")'
+    julia -e '$(juliaenvstring)using AzManagers; AzManagers.detachedservice(;subscriptionid="$subscriptionid", resourcegroup="$resourcegroup", vmname="$vmname")'
     EOF
     """
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,13 @@
-using Distributed, AzManagers, Random, Test, HTTP, AzSessions, JSON, Pkg
+using Distributed, AzManagers, Random, TOML, Test, HTTP, AzSessions, JSON, Pkg
 
 include(joinpath(homedir(), "azmanagers-setup.jl"))
 
 session = AzSession(;protocal=AzClientCredentials, client_id=client_id, client_secret=client_secret)
+
+azmanagers_pinfo = Pkg.project()
+pkgs=TOML.parse(read(joinpath(dirname(azmanagers_pinfo.path),"Manifest.toml"), String))
+pkg=pkgs["AzManagers"][1]
+azmanagers_rev=get(pkg, "repo-rev", "")
 
 @testset "AzManagers, addprocs, ppi=$ppi" for ppi in (1,)
     ninstances = 1
@@ -90,7 +95,9 @@ end
     Pkg.add("Distributed")
     Pkg.add("JSON")
     Pkg.add("HTTP")
-    Pkg.add(PackageSpec(name="AzManagers", rev="$(ENV["COMMIT_SHA"])"))
+
+    Pkg.add(PackageSpec(name="AzManagers", rev=azmanagers_rev))
+
     run(`git init`)
     run(`git add Manifest.toml`)
     run(`git add Project.toml`)
@@ -125,7 +132,9 @@ end
     Pkg.add("Distributed")
     Pkg.add("JSON")
     Pkg.add("HTTP")
-    Pkg.add(PackageSpec(name="AzManagers", rev="$(ENV["COMMIT_SHA"])"))
+
+    Pkg.add(PackageSpec(name="AzManagers", rev=azmanagers_rev))
+
     run(`git init`)
     run(`git add Manifest.toml`)
     run(`git add Project.toml`)


### PR DESCRIPTION
This fixes #33.  Previous to this PR, we used the default environment path (e.g. ~/.julia/environments/v1.5).   Using #37 instead.