### PR TITLE
Various unit test updates

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -32,6 +32,18 @@ jobs:
       - name: Create an SSH Key Pair
         run: ssh-keygen -f /home/runner/.ssh/azmanagers_rsa -N ''
 
+      - name: Template the Packer Image file
+        uses: cuchi/jinja2-action@v1.2.0
+        with:
+          template: test/templates/cofii-base.json.j2
+          output_file: test/templates/cofii-base.json
+
+      - name: Template the AzManagers Setup script
+        uses: cuchi/jinja2-action@v1.2.0
+        with:
+          template: test/templates/azmanagers-setup.jl.j2
+          output_file: test/templates/azmanagers-setup.jl
+
       - name: Create Prereq. Azure Resources
         run: |
           az login --service-principal   -u "$CLIENT_ID" -p "$CLIENT_SECRET" -t "$TENANT_ID"
@@ -44,18 +56,6 @@ jobs:
           az network vnet create         -g "$RESOURCE_GROUP" -n "$VNET_NAME" --subnet-name "$SUBNET_NAME"
           az network vnet subnet update  -g "$RESOURCE_GROUP" -n "$SUBNET_NAME" --vnet-name "$VNET_NAME" --network-security-group "$NSG_NAME"
 
-      - name: Template the Packer Image file
-        uses: cuchi/jinja2-action@v1.2.0
-        with:
-          template: /home/runner/work/AzManagers.jl/AzManagers.jl/test/templates/cofii-base.json.j2
-          output_file: /home/runner/work/AzManagers.jl/AzManagers.jl/test/templates/cofii-base.json
-
-      - name: Template the AzManagers Setup script
-        uses: cuchi/jinja2-action@v1.2.0
-        with:
-          template: /home/runner/work/AzManagers.jl/AzManagers.jl/test/templates/azmanagers-setup.jl.j2
-          output_file: /home/runner/work/AzManagers.jl/AzManagers.jl/test/templates/azmanagers-setup.jl
-
       - name: Install Packer
         run: |
           curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
@@ -63,7 +63,7 @@ jobs:
           sudo apt-get update && sudo apt-get install packer
 
       - name: Build Packer Image
-        run: packer build -color=false -timestamp-ui /home/runner/work/AzManagers.jl/AzManagers.jl/test/templates/cofii-base.json
+        run: packer build -color=false -timestamp-ui ${GITHUB_WORKSPACE}/test/templates/cofii-base.json
 
       - name: Create Master VM
         run: |
@@ -75,24 +75,12 @@ jobs:
           ipaddress=$(az network public-ip show -g "$RESOURCE_GROUP" -n "$PUBLIC_IP_NAME" | jq '.ipAddress' | cut -d "\"" -f 2)
           echo ""
 
-          echo "scp-ing the Runner ssh keys to the Master VM..."
-          scp -o StrictHostKeyChecking=no -i /home/runner/.ssh/azmanagers_rsa /home/runner/.ssh/azmanagers_rsa.pub cvx@$ipaddress:/home/cvx/.ssh/azmanagers_rsa.pub
-          scp -o StrictHostKeyChecking=no -i /home/runner/.ssh/azmanagers_rsa /home/runner/.ssh/azmanagers_rsa cvx@$ipaddress:/home/cvx/.ssh/azmanagers_rsa
-          echo ""
-
-          echo "Preparing for proper Code Coverage..."
-          ssh -o StrictHostKeyChecking=no -i /home/runner/.ssh/azmanagers_rsa cvx@$ipaddress "julia -e 'using Pkg; pkg\"dev AzManagers\"'"
-          ssh -o StrictHostKeyChecking=no -i /home/runner/.ssh/azmanagers_rsa cvx@$ipaddress "cd ~/.julia/dev/AzManagers/"
-          echo ""
-
           echo "Running the Unit Tests and Code Coverage..."
-          ssh -o StrictHostKeyChecking=no -i /home/runner/.ssh/azmanagers_rsa cvx@$ipaddress "julia --code-coverage -e 'using Pkg; Pkg.test(\"AzManagers\"; coverage=true)'"
-          ssh -o StrictHostKeyChecking=no -i /home/runner/.ssh/azmanagers_rsa cvx@$ipaddress "cd ~/.julia/dev/AzManagers/; julia -e 'include(\"/home/cvx/julia-codecov.jl\")'"
+          ssh -o StrictHostKeyChecking=no -i /home/runner/.ssh/azmanagers_rsa cvx@$ipaddress "julia -e 'using Pkg; Pkg.test(\"AzManagers\"; coverage=true); using AzManagers; include(joinpath(pkgdir(AzManagers), \"test\", \"julia-codecov.jl\"))'"
           echo ""
 
-          echo "Grabbing and scp-ing the Coverage Report..."
-          lcovpath=$(ssh -o StrictHostKeyChecking=no -i /home/runner/.ssh/azmanagers_rsa cvx@$ipaddress "find -name lcov.info")
-          scp -o StrictHostKeyChecking=no -i /home/runner/.ssh/azmanagers_rsa cvx@$ipaddress:$lcovpath /home/runner/lcov.info
+          echo "scp-ing the Coverage Report..."
+          scp -o StrictHostKeyChecking=no -i /home/runner/.ssh/azmanagers_rsa cvx@$ipaddress:/home/cvx/lcov.info lcov.info
 
       - uses: codecov/codecov-action@v1
         with:

--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -1001,7 +1001,7 @@ function buildstartupscript_detached(manager::AzManager, julia_num_threads::Int,
     $envstring
     export JULIA_NUM_THREADS=$julia_num_threads
     export OMP_NUM_THREADS=$omp_num_threads
-    ssh-keygen -f /home/$user/.ssh/azmanagers_rsa -N ''
+    ssh-keygen -f /home/$user/.ssh/azmanagers_rsa -N '' <<<y
     cd /home/$user
     julia -e 'using AzManagers; AzManagers.detachedservice(;subscriptionid="$subscriptionid", resourcegroup="$resourcegroup", vmname="$vmname")'
     EOF

--- a/test/julia-codecov.jl
+++ b/test/julia-codecov.jl
@@ -1,3 +1,3 @@
-using Coverage
-coverage = process_folder()
+using Coverage, AzManagers
+coverage = process_folder(pkgdir(AzManagers))
 LCOV.writefile("lcov.info", coverage)

--- a/test/templates/cofii-base.json.j2
+++ b/test/templates/cofii-base.json.j2
@@ -34,7 +34,6 @@
   "provisioners":
   [
     {
-      "only": ["azure-arm"],
       "type": "shell",
       "inline":
       [
@@ -51,7 +50,7 @@
       [
         "sudo apt-get -y update",
         "sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" upgrade",
-        "sudo apt-get -y install build-essential mpich libcurl4-openssl-dev emacs-nox nodejs npm git vim",
+        "sudo apt-get -y install build-essential mpich git",
         "sudo sed -i '1 i *     soft    nofile  1000000' /etc/security/limits.conf",
         "sudo sed -i '1 i *     hard    nofile  1000000' /etc/security/limits.conf",
         "sudo sed -i '1 i fs.inotify.max_user_watches=65536' /etc/sysctl.conf",
@@ -63,24 +62,20 @@
       "type": "shell",
       "inline":
       [
-        "sudo wget https://julialang-s3.julialang.org/bin/linux/x64/{{ env['JULIA_VERSION'] }}/julia-{{ env['JULIA_VERSION'] }}.0-linux-x86_64.tar.gz"
+        "ssh-keygen -f /home/cvx/.ssh/azmanagers_rsa -N ''"
       ]
     },
     {
       "type": "file",
-      "source": "/home/runner/work/AzManagers.jl/AzManagers.jl/test/templates/azmanagers-setup.jl",
+      "source": "test/templates/azmanagers-setup.jl",
       "destination": "/home/cvx/azmanagers-setup.jl"
-    },
-    {
-      "type": "file",
-      "source": "/home/runner/work/AzManagers.jl/AzManagers.jl/test/julia-codecov.jl",
-      "destination": "/home/cvx/julia-codecov.jl"
     },
     {
       "type": "shell",
       "inline":
       [
         "echo \"installing Julia\"",
+        "sudo wget https://julialang-s3.julialang.org/bin/linux/x64/{{ env['JULIA_VERSION'] }}/julia-{{ env['JULIA_VERSION'] }}.0-linux-x86_64.tar.gz",
         "mkdir ~/.julia",
         "sudo tar --strip-components=1 -xzvf julia-{{ env['JULIA_VERSION'] }}.0-linux-x86_64.tar.gz -C /opt/julia",
         "sudo rm -f julia-{{ env['JULIA_VERSION'] }}.0-linux-x86_64.tar.gz",


### PR DESCRIPTION
The main fixes here are to remove the loop over the unit test case (was not parsing properly), and to make sure that we are calling the version of runtests.jl that is consistent with the version of AzManagers that is on the cluster.  In addition, the simplifications made to the code coverage stuff should fix the code coverage badge problems.