### PR TITLE
use current environment, and do not use git for projects

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "2.1.0"
 [deps]
 AzSessions = "f239b30d-ae6b-58be-a2d5-7e9f30e280a9"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
@@ -20,13 +21,15 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
 AzSessions = "1"
+CodecZlib = "0.7"
 HTTP = "0.8, 0.9"
 JSON = "0.21"
 MPI = "0.14, 0.15, 0.16"
-julia = "1"
+julia = "^1.4"
 
 [extras]
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["TOML", "Test"]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -160,19 +160,16 @@ VM via a mix of MPI and OpenMP.
 
 # Custom environments
 AzManagers can create an on-the-fly custom Julia software environment for the workers.
-This is managed via Julia environments.  If you update your Julia environment, then
-you can, commit those updates to a branch and push that branch to a remote.  Subsequently, 
-when you create a cluster, the worker nodes will, at boot time, instantiate the environment.
-For example:
-```sh
-julia -e `using Pkg; pkg"add FFTW"`
-cd /home/cvx/.julia/environments/v1.5
-git branch custom_environment
-git add Manifest.toml
-git add Project.toml
-git commit -m "custom environment"
-git push origin custom_environment
+This is managed via Julia environments.  If you use the `customenv=true` keyword argument, then
+when you create a cluster, the worker nodes will, at boot time, instantiate the
+environment. For example:
+```julia
+using Pkg
+Pkg.instantiate(".")
+Pkg.add("AzManagers")
+Pkg.add("Jets")
+addprocs("cbox16",2;customenv=true)
 ```
 Now, when worker VMs are initialized, they will have the software stack
-defined in `custom_environment`.  Please note that this can add significant
+defined by the current project.  Please note that this can add significant
 overhead to the boot-time of the VMs.


### PR DESCRIPTION
in addition to #34, this sends the environment (Project.toml and Manifest.toml) using cloud init instead of using a remote git repository.

The downside of not using git is that it might be possible to run into the 64 KB size limit for cloud init.  But, in my initial testing that does not seem to be a problem, and the cloud init data seems to run at about 20 KB, leaving room for larger environments.

The other downside is that the user needs to pass the `customenv=true` keyword argument to `addprocs` or `addproc` if they want to send the environment.