### PR TITLE
Option for attaching extra disk to vm's.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 AzSessions = "1"


### PR DESCRIPTION
This should work for both vm's via `addproc` and scalesets via `addprocs`.  The extra disks are specified by the `datadisks` parameter in the templates.

For example,

```
template = AzManagers.build_vmtemplate("test",
    subscriptionid = "mysub",
    admin_username = "user",
    location = "myloc",
    resourcegroup = "mygroup",
    resourcegroup_vnet = "myvnetgroup",
    imagegallery = "mygallery",
    imagename = "myimage",
    vnet = "myvnet",
    subnet = "mysubnet",
    vmsize = "Standard_D16s_v3",
    datadisks = [Dict("diskSizeGB"=>100), Dict("diskSizeGB"=>200)])

myvm = addproc(template)
```

This will create two additional disks, and attach them to `myvm`.  The first disk will be mounted at `/sractch1`, and the second disk will be mounted at `/scratch2`.