### PR TITLE
configurable polling interval

### DIFF
--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -175,9 +175,10 @@ end
 function scaleset_monitor()
     manager = azmanager()
     tic = time()
+    interval = get(ENV, "JULIA_AZMANAGERS_POLL_INTERVAL", 60)
     while true
         try
-            sleep(10)
+            sleep(interval)
             delete_empty_scalesets()
             delete_pending_down_vms()
 


### PR DESCRIPTION
the number of times we poll for scaleset information can
have a significant impact on Azure's API limits.