### PR TITLE
Robust kill method

### DIFF
--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -532,7 +532,10 @@ function Distributed.launch(manager::AzManager, params::Dict, launched::Array, c
 end
 
 function Distributed.kill(manager::AzManager, id::Int, config::WorkerConfig)
-    remote_do(exit, id)
+    try
+        remote_do(exit, id)
+    catch
+    end
 
     u = config.userdata
 


### PR DESCRIPTION
We add a catch around the remote_do.  This seems required when the julia
worker process exits (e.g. due to a seg-fault).