### PR TITLE
Fix escaping in cloud-init script

### DIFF
--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -1196,7 +1196,7 @@ function buildstartupscript(manager::AzManager, user::String, disk::AbstractStri
         cmd *= """
         
         sudo su - $user << EOF
-        echo "$gitconfig" > ~/.gitconfig
+        echo '$gitconfig' > ~/.gitconfig
         EOF
         """
     end


### PR DESCRIPTION
This allows users to have `"` in their .gitconfig file.