### PR TITLE
BREAKING: Don't pirate the `Distributed.addprocs` function; introduce a new `AzManagers.addprocs_azure` function instead

### DIFF
--- a/demo/detached.jl
+++ b/demo/detached.jl
@@ -67,7 +67,8 @@ sessionbundle!(
 
 job4 = @detach vm(;session=sessionbundle(:management),persist=true) begin
     using Distributed, AzManagers, AzStorage, AzSessions
-    addprocs("cbox04", 4; session=sessionbundle(:management))
+    using AzManagers: addprocs_azure
+    addprocs_azure("cbox04", 4; session=sessionbundle(:management))
 
     for pid in workers()
         hostname = remotecall_fetch(gethostname, pid)

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -5,8 +5,10 @@
 ```julia
 using Distributed, AzManagers
 
+using AzManagers: addprocs_azure
+
 # add 10 instances to an Azure scale set with the "cbox08" scale-set template.
-addprocs("cbox08", 10)
+addprocs_azure("cbox08", 10)
 
 # monitor the workers as they join the Julia cluster.
 while nprocs() == nworkers() || nworkers() < 10
@@ -16,7 +18,7 @@ end
 length(workers()) # 10
 
 # add 10 more instances, waiting for the cluster to be stable before returning control to the caller.
-addprocs("cbox08", 10; waitfor=true)
+addprocs_azure("cbox08", 10; waitfor=true)
 length(workers()) # 20
 
 # remove the first 5 instances
@@ -26,10 +28,10 @@ rmprocs(workers()[1:5])
 rmprocs(workers())
 
 # list self-doc for AzManagers addprocs method:
-?addprocs
+?addprocs_azure
 
 # make a scale-set from SPOT VMs
-addprocs("cbox08", 10; group="myspotgroup", spot=true)
+addprocs_azure("cbox08", 10; group="myspotgroup", spot=true)
 
 # wait for at-least one worker to be available
 while nprocs() - nworkers() == 0; yield(); end

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,16 +6,18 @@ uses a user-defined template.  For example, we can create a new julia cluster co
 5 VMs, and where the scale-set is described by the template `"myscaleset"` as follows,
 ```julia
 using AzManagers, Distributed
-addprocs("myscaleset", 5)
+using AzManagers: addprocs_azure
+addprocs_azure("myscaleset", 5)
 ```
 Note that `addprocs` will return as soon as the provisioning is initialized.  Subsequently, workers
-will add themselves to the Julia cluster as they become available.  This is similar to the "elastic.jl" 
+will add themselves to the Julia cluster as they become available.  This is similar to the "elastic.jl"
 cluster manager in [ClusterManagers.jl](https://github.com/JuliaParallel/ClusterManagers.jl), and allows
 AzManagers to behave dynamically.  To wait for the cluster to be completely up use the `waitfor` argument.
 For example,
 ```julia
 using AzManagers, Distributed
-addprocs("myscaleset", 5; waitfor=true)
+using AzManagers: addprocs_azure
+addprocs_azure("myscaleset", 5; waitfor=true)
 ```
 In this case `addprocs` will return only once the 5 workers have joined the cluster.
 
@@ -27,7 +29,7 @@ for more information.
 
 AzManagers does not provide scale-set templates since they will depend on your specific Azure
 setup.  However, we provide a means to create the templates.  Please see the section
-[Scale-set templates](# Scale-set templates) for more information. 
+[Scale-set templates](# Scale-set templates) for more information.
 
 AzManagers requires a user provided Azure resource group and subscription, as well as information
 about the ssh user for the scale-set VMs.  AzManagers uses a manifest file to store this information.
@@ -60,7 +62,7 @@ myscaleset = AzManagers.build_sstemplate("myvm",
 AzManagers.save_template_scaleset("myscaleset", myscaleset)
 ```
 The above code will save the template to the json file, `~/.azmanagers/templates_scaleset.json`.
-Subsequently, `addprocs("myscaleset", 5)` will query the json file for the VM template.  One can
+Subsequently, `addprocs_azure("myscaleset", 5)` will query the json file for the VM template.  One can
 repeat this process, populating `~/.azmanagers/templates_scaleset.json` with a variety of templates
 for a variety of machine types.
 
@@ -82,7 +84,7 @@ AzManagers.write_manifest(;
     resourcegroup  = "my-resource-group",
     subscriptionid = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
     ssh_user = "username")
-``` 
+```
 One can also specify the locations of the public and private ssh keys which AzManagers will use
 to establish ssh connections to the cluster machines.  This connection is used for the initial
 set-up of the cluster, and for sending log messages back to the master process.  By default,
@@ -100,7 +102,8 @@ such as azure log analytics might be useful.  At this time, AzManagers does not 
 logger; but, if one had such a logger (e.g. MyAzureLogger), then one would do:
 ```
 using AzManagers, Distributed
-addprocs("myscaleset",5)
+using AzManagers: addprocs_azure
+addprocs_azure("myscaleset",5)
 @everywhere using Logging, MyAzureLogger
 @everywhere global_logger(MyAzureLogger())
 ```
@@ -143,7 +146,8 @@ variablebundle!(session = AzSession())
 myvm = addproc("myvm")
 detached_job = @detachat myvm begin
     using Distributed, AzManagers
-    addprocs("myscaleset", 5; session=variablebundle(:session))
+    using AzManagers: addprocs_azure
+    addprocs_azure("myscaleset", 5; session=variablebundle(:session))
     for pid in workers()
         remotecall_fetch(println, "hello from pid=$(myid())")
     end
@@ -169,7 +173,8 @@ using Pkg
 Pkg.instantiate(".")
 Pkg.add("AzManagers")
 Pkg.add("Jets")
-addprocs("cbox16",2;customenv=true)
+using AzManagers: addprocs_azure
+addprocs_azure("cbox16",2;customenv=true)
 ```
 Now, when worker VMs are initialized, they will have the software stack
 defined by the current project.  Please note that this can add significant

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -2,7 +2,7 @@
 
 ## Julia clusters
 ```@docs
-addprocs
+addprocs_azure
 preempted
 ```
 

--- a/src/templates.jl
+++ b/src/templates.jl
@@ -29,7 +29,7 @@ end
 """
     AzManagers.build_sstemplate(name; kwargs...)
 
-returns a dictionary that is an Azure scaleset template for use in `addprocs` or for saving
+returns a dictionary that is an Azure scaleset template for use in `addprocs_azure` or for saving
 to the `~/.azmanagers` folder.
 
 # required key-word arguments
@@ -260,7 +260,7 @@ or written to AzManagers.jl configuration files.
 * `location` Azure data center location
 * `resourcegroup` Azure resource group where the VM will reside
 * `imagegallery` Azure shared image gallery name
-* `imagename` Azure image name that is in the shared image gallery 
+* `imagename` Azure image name that is in the shared image gallery
 * `vmsize` Azure vm type, e.g. "Standard_D8s_v3"
 
 # Optional keyword arguments
@@ -273,7 +273,7 @@ or written to AzManagers.jl configuration files.
 * `tempdisk = "sudo mkdir -m 777 /mnt/scratch\nln -s /mnt/scratch /scratch"`  cloud-init commands used to mount or link to temporary disk
 * `tags = Dict("azure_tag_name" => "some_tag_value")` Optional tags argument for resource
 * `encryption_at_host = false` Optional argument for enabling encryption at host
-* `default_nic = ""` Optional argument for inserting "default_nic" as a key 
+* `default_nic = ""` Optional argument for inserting "default_nic" as a key
 
 # Notes
 [1] Each datadisk is a Dictionary. For example,


### PR DESCRIPTION
Fixes #175.

This is a breaking change, and thus after this PR is merged, the next release of this package will need to be a breaking release, e.g. 4.0.0.