### PR TITLE
specify the executable for detached jobs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AzManagers"
 uuid = "db05ebb0-6096-11e9-199b-87b703361841"
 authors = ["samtkaplan <sam.kaplan@chevron.com>"]
-version = "3.16.0"
+version = "3.17.0"
 
 [deps]
 AzSessions = "f239b30d-ae6b-58be-a2d5-7e9f30e280a9"


### PR DESCRIPTION
this is useful when, for example, we need to start Julia with mpi: `mpirun -n 1 julia`.  This, in turn, is useful for how Devito does domain decomposition across NUMA domains.