### PR TITLE
add SSH retry loop to CI before running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,47 +6,34 @@ on:
   pull_request:
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - 1.6
-          - 1
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
+    name: Julia tests
+    runs-on: ubuntu-latest
     env:
-      TENANT_ID: "${{ secrets.TENANT_ID }}" 
+      TENANT_ID: "${{ secrets.TENANT_ID }}"
       SUBSCRIPTION_ID: "${{ secrets.SUBSCRIPTION_ID }}"
-      RESOURCE_GROUP: "AzureBackupRG-azman-${{ matrix.os }}-${{ matrix.version }}-${{ github.run_id }}"
+      RESOURCE_GROUP: "AzureBackupRG-azman-${{ github.run_id }}"
       CLIENT_ID: "${{ secrets.CLIENT_ID }}"
       CLIENT_SECRET: "${{ secrets.CLIENT_SECRET }}"
-      GALLERY_NAME: "${{ github.run_id }}${{ matrix.version }}gallery"
-      IMAGE_NAME: "${{ matrix.os }}-${{ matrix.version }}-${{ github.run_id }}-image"
       PERSISTENT_RG: "AzureBackupRG-azman-imgcache"
       PERSISTENT_GALLERY: "azmanciimages"
       CACHE_MAX_AGE_DAYS: 30
-      VM_NAME: "${{ matrix.os }}-${{ matrix.version }}-${{ github.run_id }}-vm"
-      PUBLIC_IP_NAME: "${{ matrix.os }}-${{ matrix.version }}-${{ github.run_id }}-pubip"
-      VNET_NAME: "${{ matrix.os }}-${{ matrix.version }}-${{ github.run_id }}-vnet"
-      NSG_NAME: "${{ matrix.os }}-${{ matrix.version }}-${{ github.run_id }}-nsg"
+      VM_NAME: "azman-${{ github.run_id }}-vm"
+      PUBLIC_IP_NAME: "azman-${{ github.run_id }}-pubip"
+      VNET_NAME: "azman-${{ github.run_id }}-vnet"
+      NSG_NAME: "azman-${{ github.run_id }}-nsg"
       SUBNET_NAME: "default"
-      COMMIT_SHA: "${{ github.sha }}"
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
         with:
-          version: ${{ matrix.version }}
+          version: '1'
 
       - name: Create an SSH Key Pair
         run: ssh-keygen -f /home/runner/.ssh/azmanagers_rsa -N ''
 
-      - name: Create Prereq. Azure Resources
+      - name: Create Azure Resources
         run: |
-          az login --service-principal   -u "$CLIENT_ID" -p "$CLIENT_SECRET" -t "$TENANT_ID"
+          az login --service-principal -u "$CLIENT_ID" -p "$CLIENT_SECRET" -t "$TENANT_ID"
           az group create                -g "$RESOURCE_GROUP" -l southcentralus --tags "CostElement=YWED10528906" "CompanyCode=0322" "environment=dev" "OwnerEmail=sam.kaplan@chevron.com"
           az group wait                  -g "$RESOURCE_GROUP" --created
           az network nsg create          -g "$RESOURCE_GROUP" -n "$NSG_NAME"
@@ -65,7 +52,7 @@ jobs:
           echo "JULIA_VERSION_PATCH=$JULIA_VERSION_PATCH" >> $GITHUB_ENV
           echo "CACHE_IMAGE_DEF=$CACHE_IMAGE_DEF" >> $GITHUB_ENV
 
-          # Ensure persistent resource group and gallery exist (these are idempotent)
+          # Ensure persistent resource group and gallery exist
           az group create -g "$PERSISTENT_RG" -l southcentralus \
             --tags "CostElement=YWED10528906" "CompanyCode=0322" "environment=dev" \
                    "OwnerEmail=sam.kaplan@chevron.com" "purpose=ci-image-cache"
@@ -131,7 +118,10 @@ jobs:
 
       - name: Create coordinator VM
         run: |
-          az vm create -g "$RESOURCE_GROUP" -n "$VM_NAME" --image "$CACHED_IMAGE_ID" --public-ip-sku Standard --public-ip-address "$PUBLIC_IP_NAME" --subnet "$SUBNET_NAME" --vnet-name "$VNET_NAME" --nsg "$NSG_NAME" --ssh-key-values @/home/runner/.ssh/azmanagers_rsa.pub --admin-username cvx
+          az vm create -g "$RESOURCE_GROUP" -n "$VM_NAME" --image "$CACHED_IMAGE_ID" \
+            --public-ip-sku Standard --public-ip-address "$PUBLIC_IP_NAME" \
+            --subnet "$SUBNET_NAME" --vnet-name "$VNET_NAME" --nsg "$NSG_NAME" \
+            --ssh-key-values @/home/runner/.ssh/azmanagers_rsa.pub --admin-username cvx
 
       - name: Update AzManagers and regenerate templates
         run: |
@@ -178,7 +168,8 @@ jobs:
           ipaddress=$(az network public-ip show -g "$RESOURCE_GROUP" -n "$PUBLIC_IP_NAME" | jq -r '.ipAddress')
 
           echo "Running the Unit Tests and Code Coverage..."
-          ssh -o StrictHostKeyChecking=no -i /home/runner/.ssh/azmanagers_rsa cvx@$ipaddress "julia -e 'using Pkg; Pkg.test(\"AzManagers\"; coverage=true); using AzManagers; include(joinpath(pkgdir(AzManagers), \"test\", \"julia-codecov.jl\"))'"
+          ssh -o StrictHostKeyChecking=no -i /home/runner/.ssh/azmanagers_rsa cvx@$ipaddress \
+            "julia -e 'using Pkg; Pkg.test(\"AzManagers\"; coverage=true); using AzManagers; include(joinpath(pkgdir(AzManagers), \"test\", \"julia-codecov.jl\"))'"
           echo ""
 
           echo "scp-ing the Coverage Report..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,21 @@ jobs:
           ipaddress=$(az network public-ip show -g "$RESOURCE_GROUP" -n "$PUBLIC_IP_NAME" | jq '.ipAddress' | cut -d "\"" -f 2)
           echo ""
 
+          echo "Waiting for SSH to become available on $ipaddress..."
+          for i in $(seq 1 30); do
+            if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 -i /home/runner/.ssh/azmanagers_rsa cvx@$ipaddress "echo ready" 2>/dev/null; then
+              echo "SSH is ready after attempt $i"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "SSH not available after 30 attempts, giving up."
+              exit 1
+            fi
+            echo "Attempt $i: SSH not ready, retrying in 10 seconds..."
+            sleep 10
+          done
+          echo ""
+
           echo "Running the Unit Tests and Code Coverage..."
           ssh -o StrictHostKeyChecking=no -i /home/runner/.ssh/azmanagers_rsa cvx@$ipaddress "julia -e 'using Pkg; Pkg.test(\"AzManagers\"; coverage=true); using AzManagers; include(joinpath(pkgdir(AzManagers), \"test\", \"julia-codecov.jl\"))'"
           echo ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,11 +118,7 @@ jobs:
 
       - name: Create coordinator VM
         run: |
-          az vm create -g "$RESOURCE_GROUP" -n "$VM_NAME" --image "$CACHED_IMAGE_ID" \
-            --size Standard_D2s_v5 \
-            --public-ip-sku Standard --public-ip-address "$PUBLIC_IP_NAME" \
-            --subnet "$SUBNET_NAME" --vnet-name "$VNET_NAME" --nsg "$NSG_NAME" \
-            --ssh-key-values @/home/runner/.ssh/azmanagers_rsa.pub --admin-username cvx
+          az vm create -g "$RESOURCE_GROUP" -n "$VM_NAME" --image "$CACHED_IMAGE_ID" --size Standard_D2s_v5 --public-ip-sku Standard --public-ip-address "$PUBLIC_IP_NAME" --subnet "$SUBNET_NAME" --vnet-name "$VNET_NAME" --nsg "$NSG_NAME" --ssh-key-values @/home/runner/.ssh/azmanagers_rsa.pub --admin-username cvx
 
       - name: Update AzManagers and regenerate templates
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
       - name: Create coordinator VM
         run: |
           az vm create -g "$RESOURCE_GROUP" -n "$VM_NAME" --image "$CACHED_IMAGE_ID" \
+            --size Standard_D2s_v5 \
             --public-ip-sku Standard --public-ip-address "$PUBLIC_IP_NAME" \
             --subnet "$SUBNET_NAME" --vnet-name "$VNET_NAME" --nsg "$NSG_NAME" \
             --ssh-key-values @/home/runner/.ssh/azmanagers_rsa.pub --admin-username cvx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,14 +65,18 @@ jobs:
           echo "JULIA_VERSION_PATCH=$JULIA_VERSION_PATCH" >> $GITHUB_ENV
           echo "CACHE_IMAGE_DEF=$CACHE_IMAGE_DEF" >> $GITHUB_ENV
 
-          # Ensure persistent resource group and gallery exist
+          # Ensure persistent resource group and gallery exist (these are idempotent)
           az group create -g "$PERSISTENT_RG" -l southcentralus \
             --tags "CostElement=YWED10528906" "CompanyCode=0322" "environment=dev" \
-                   "OwnerEmail=sam.kaplan@chevron.com" "purpose=ci-image-cache" 2>/dev/null || true
-          az sig create -g "$PERSISTENT_RG" -r "$PERSISTENT_GALLERY" 2>/dev/null || true
+                   "OwnerEmail=sam.kaplan@chevron.com" "purpose=ci-image-cache"
+          az sig create -g "$PERSISTENT_RG" -r "$PERSISTENT_GALLERY" || true
+
+          # Create image definition if it doesn't already exist
+          az sig image-definition show -g "$PERSISTENT_RG" -r "$PERSISTENT_GALLERY" \
+            -i "$CACHE_IMAGE_DEF" > /dev/null 2>&1 || \
           az sig image-definition create -g "$PERSISTENT_RG" -r "$PERSISTENT_GALLERY" \
             -i "$CACHE_IMAGE_DEF" -p "canonical" -f "0001-com-ubuntu-server-jammy" \
-            -s "22_04-lts-gen2" --os-type linux --hyper-v-generation V2 2>/dev/null || true
+            -s "22_04-lts-gen2" --os-type linux --hyper-v-generation V2
 
           # Check for a recent image version
           CUTOFF_DATE=$(date -d "-${CACHE_MAX_AGE_DAYS} days" -u +%Y-%m-%dT%H:%M:%S)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       CLIENT_SECRET: "${{ secrets.CLIENT_SECRET }}"
       GALLERY_NAME: "${{ github.run_id }}${{ matrix.version }}gallery"
       IMAGE_NAME: "${{ matrix.os }}-${{ matrix.version }}-${{ github.run_id }}-image"
+      PERSISTENT_RG: "AzureBackupRG-azman-imgcache"
+      PERSISTENT_GALLERY: "azmanciimages"
+      CACHE_MAX_AGE_DAYS: 30
       VM_NAME: "${{ matrix.os }}-${{ matrix.version }}-${{ github.run_id }}-vm"
       PUBLIC_IP_NAME: "${{ matrix.os }}-${{ matrix.version }}-${{ github.run_id }}-pubip"
       VNET_NAME: "${{ matrix.os }}-${{ matrix.version }}-${{ github.run_id }}-vnet"
@@ -45,51 +48,90 @@ jobs:
         run: |
           az login --service-principal   -u "$CLIENT_ID" -p "$CLIENT_SECRET" -t "$TENANT_ID"
           az group create                -g "$RESOURCE_GROUP" -l southcentralus --tags "CostElement=YWED10528906" "CompanyCode=0322" "environment=dev" "OwnerEmail=sam.kaplan@chevron.com"
-          az group wait                  -g "$RESOURCE_GROUP" --created 
-          az sig create                  -g "$RESOURCE_GROUP" -r "$GALLERY_NAME"
-          az sig image-definition create -g "$RESOURCE_GROUP" -r "$GALLERY_NAME" -i "$IMAGE_NAME" -p "canonical" -f "0001-com-ubuntu-server-jammy" -s "22_04-lts-gen2" --os-type linux --hyper-v-generation V2
+          az group wait                  -g "$RESOURCE_GROUP" --created
           az network nsg create          -g "$RESOURCE_GROUP" -n "$NSG_NAME"
           az network nsg rule create     -g "$RESOURCE_GROUP" -n "rule-$NSG_NAME" --nsg-name "$NSG_NAME" --priority 101 --source-address-prefixes "AzureCloud" --destination-port-ranges 22
           az network vnet create         -g "$RESOURCE_GROUP" -n "$VNET_NAME" --subnet-name "$SUBNET_NAME"
           az network vnet subnet update  -g "$RESOURCE_GROUP" -n "$SUBNET_NAME" --vnet-name "$VNET_NAME" --network-security-group "$NSG_NAME"
 
+      - name: Check for cached image
+        run: |
+          JULIA_VERSION_MAJOR=$(julia -e 'print(stdout, VERSION.major)')
+          JULIA_VERSION_MINOR=$(julia -e 'print(stdout, VERSION.minor)')
+          JULIA_VERSION_PATCH=$(julia -e 'print(stdout, VERSION.patch)')
+          CACHE_IMAGE_DEF="julia-${JULIA_VERSION_MAJOR}-${JULIA_VERSION_MINOR}-${JULIA_VERSION_PATCH}"
+          echo "JULIA_VERSION_MAJOR=$JULIA_VERSION_MAJOR" >> $GITHUB_ENV
+          echo "JULIA_VERSION_MINOR=$JULIA_VERSION_MINOR" >> $GITHUB_ENV
+          echo "JULIA_VERSION_PATCH=$JULIA_VERSION_PATCH" >> $GITHUB_ENV
+          echo "CACHE_IMAGE_DEF=$CACHE_IMAGE_DEF" >> $GITHUB_ENV
+
+          # Ensure persistent resource group and gallery exist
+          az group create -g "$PERSISTENT_RG" -l southcentralus \
+            --tags "CostElement=YWED10528906" "CompanyCode=0322" "environment=dev" \
+                   "OwnerEmail=sam.kaplan@chevron.com" "purpose=ci-image-cache" 2>/dev/null || true
+          az sig create -g "$PERSISTENT_RG" -r "$PERSISTENT_GALLERY" 2>/dev/null || true
+          az sig image-definition create -g "$PERSISTENT_RG" -r "$PERSISTENT_GALLERY" \
+            -i "$CACHE_IMAGE_DEF" -p "canonical" -f "0001-com-ubuntu-server-jammy" \
+            -s "22_04-lts-gen2" --os-type linux --hyper-v-generation V2 2>/dev/null || true
+
+          # Check for a recent image version
+          CUTOFF_DATE=$(date -d "-${CACHE_MAX_AGE_DAYS} days" -u +%Y-%m-%dT%H:%M:%S)
+          LATEST_VERSION=$(az sig image-version list \
+            -g "$PERSISTENT_RG" -r "$PERSISTENT_GALLERY" -i "$CACHE_IMAGE_DEF" \
+            --query "[?publishingProfile.publishedDate >= '$CUTOFF_DATE'] | sort_by(@, &publishingProfile.publishedDate) | [-1].id" \
+            -o tsv 2>/dev/null || echo "")
+
+          if [ -n "$LATEST_VERSION" ] && [ "$LATEST_VERSION" != "None" ]; then
+            echo "Found cached image: $LATEST_VERSION"
+            echo "CACHE_HIT=true" >> $GITHUB_ENV
+            echo "CACHED_IMAGE_ID=$LATEST_VERSION" >> $GITHUB_ENV
+          else
+            echo "No cached image found, will build new one"
+            echo "CACHE_HIT=false" >> $GITHUB_ENV
+          fi
+
       - name: Install Packer
+        if: env.CACHE_HIT != 'true'
         run: |
           curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
           sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
           sudo apt-get update && sudo apt-get install packer
 
       - name: Build Packer Image
+        if: env.CACHE_HIT != 'true'
         run: |
-          export JULIA_VERSION_MAJOR=$(julia -e 'print(stdout, VERSION.major)')
-          export JULIA_VERSION_MINOR=$(julia -e 'print(stdout, VERSION.minor)')
-          export JULIA_VERSION_PATCH=$(julia -e 'print(stdout, VERSION.patch)')
+          IMAGE_VERSION="1.0.$(date +%s)"
           packer init ${GITHUB_WORKSPACE}/test/image.pkr.hcl
           packer build -color=false -timestamp-ui \
             -var "subscription_id=${SUBSCRIPTION_ID}" \
             -var "tenant_id=${TENANT_ID}" \
             -var "client_id=${CLIENT_ID}" \
             -var "client_secret=${CLIENT_SECRET}" \
-            -var "resource_group=${RESOURCE_GROUP}" \
-            -var "image_name=${IMAGE_NAME}" \
+            -var "resource_group=${PERSISTENT_RG}" \
+            -var "build_resource_group=${RESOURCE_GROUP}" \
+            -var "image_name=${CACHE_IMAGE_DEF}" \
             -var "virtual_network=${VNET_NAME}" \
             -var "virtual_subnet=default" \
-            -var "gallery=${GALLERY_NAME}" \
+            -var "gallery=${PERSISTENT_GALLERY}" \
+            -var "image_version=${IMAGE_VERSION}" \
             -var "julia_version_major=${JULIA_VERSION_MAJOR}" \
             -var "julia_version_minor=${JULIA_VERSION_MINOR}" \
             -var "julia_version_patch=${JULIA_VERSION_PATCH}" \
-            -var "azmanagers_version=${{ github.sha }}" \
+            -var "azmanagers_version=master" \
             ${GITHUB_WORKSPACE}/test/image.pkr.hcl
+
+          CACHED_IMAGE_ID=$(az sig image-version list \
+            -g "$PERSISTENT_RG" -r "$PERSISTENT_GALLERY" -i "$CACHE_IMAGE_DEF" \
+            --query "sort_by(@, &publishingProfile.publishedDate) | [-1].id" -o tsv)
+          echo "CACHED_IMAGE_ID=$CACHED_IMAGE_ID" >> $GITHUB_ENV
 
       - name: Create coordinator VM
         run: |
-          az vm create -g "$RESOURCE_GROUP" -n "$VM_NAME" --image "$IMAGE_NAME" --public-ip-sku Standard --public-ip-address "$PUBLIC_IP_NAME" --subnet "$SUBNET_NAME" --vnet-name "$VNET_NAME" --nsg "$NSG_NAME" --ssh-key-values @/home/runner/.ssh/azmanagers_rsa.pub --admin-username cvx
+          az vm create -g "$RESOURCE_GROUP" -n "$VM_NAME" --image "$CACHED_IMAGE_ID" --public-ip-sku Standard --public-ip-address "$PUBLIC_IP_NAME" --subnet "$SUBNET_NAME" --vnet-name "$VNET_NAME" --nsg "$NSG_NAME" --ssh-key-values @/home/runner/.ssh/azmanagers_rsa.pub --admin-username cvx
 
-      - name: Run the unit tests
+      - name: Update AzManagers and regenerate templates
         run: |
-          echo "Grabbing the coordinator VM's Pubic IP Address..."
-          ipaddress=$(az network public-ip show -g "$RESOURCE_GROUP" -n "$PUBLIC_IP_NAME" | jq '.ipAddress' | cut -d "\"" -f 2)
-          echo ""
+          ipaddress=$(az network public-ip show -g "$RESOURCE_GROUP" -n "$PUBLIC_IP_NAME" | jq -r '.ipAddress')
 
           echo "Waiting for SSH to become available on $ipaddress..."
           for i in $(seq 1 30); do
@@ -104,7 +146,32 @@ jobs:
             echo "Attempt $i: SSH not ready, retrying in 10 seconds..."
             sleep 10
           done
-          echo ""
+
+          echo "Updating AzManagers to ${{ github.sha }}..."
+          ssh -o StrictHostKeyChecking=no -i /home/runner/.ssh/azmanagers_rsa cvx@$ipaddress \
+            "julia -e 'using Pkg; Pkg.add(PackageSpec(name=\"AzManagers\", rev=\"${{ github.sha }}\"))'"
+
+          echo "Copying templates.jl to VM..."
+          scp -o StrictHostKeyChecking=no -i /home/runner/.ssh/azmanagers_rsa \
+            ${GITHUB_WORKSPACE}/test/templates.jl cvx@$ipaddress:/tmp/templates.jl
+
+          echo "Regenerating templates..."
+          ssh -o StrictHostKeyChecking=no -i /home/runner/.ssh/azmanagers_rsa cvx@$ipaddress \
+            "TENANT_ID='${TENANT_ID}' \
+             SUBSCRIPTION_ID='${SUBSCRIPTION_ID}' \
+             RESOURCE_GROUP='${RESOURCE_GROUP}' \
+             CLIENT_ID='${CLIENT_ID}' \
+             CLIENT_SECRET='${CLIENT_SECRET}' \
+             IMAGE_NAME='${CACHE_IMAGE_DEF}' \
+             VNET_NAME='${VNET_NAME}' \
+             SUBNET_NAME='${SUBNET_NAME}' \
+             GALLERY_NAME='${PERSISTENT_GALLERY}' \
+             GALLERY_RG='${PERSISTENT_RG}' \
+             julia /tmp/templates.jl"
+
+      - name: Run the unit tests
+        run: |
+          ipaddress=$(az network public-ip show -g "$RESOURCE_GROUP" -n "$PUBLIC_IP_NAME" | jq -r '.ipAddress')
 
           echo "Running the Unit Tests and Code Coverage..."
           ssh -o StrictHostKeyChecking=no -i /home/runner/.ssh/azmanagers_rsa cvx@$ipaddress "julia -e 'using Pkg; Pkg.test(\"AzManagers\"; coverage=true); using AzManagers; include(joinpath(pkgdir(AzManagers), \"test\", \"julia-codecov.jl\"))'"

--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -605,8 +605,8 @@ function process_pending_connections()
                         manager.preempt_channel_futures[pid] = remotecall(Channel{Bool}, pid, 1)
                         remotecall_fetch(machine_preempt_loop, pid, manager.preempt_channel_futures[pid])
                     catch e
-                        if isa(e, RemoteException) && isa(e.captured.ex, TaskFailedException) && isa(e.captured.ex.task.result.ex, SpotPreemptException)
-                            ex = e.captured.ex.task.result.ex
+                        ex = _extract_preempt_exception(e)
+                        if ex !== nothing
                             notbefore = DateTime(ex.notbefore, dateformat"e, dd u yyyy HH:MM:SS \G\M\T")
                             @info "caught preempt exception for $(ex.clusterid), removing not before $notbefore UTC"
                             _now = now(UTC)
@@ -619,7 +619,7 @@ function process_pending_connections()
                                 scaleset = ScaleSet(u["subscriptionid"], u["resourcegroup"], u["scalesetname"])
                                 add_instance_to_preempted_list(manager, scaleset, u["instanceid"])
                             catch e
-                                @info "error adding instance to preempted list"
+                                @warn "error adding instance to preempted list" exception=e
                             end
 
                             try
@@ -630,10 +630,13 @@ function process_pending_connections()
                                     Distributed.set_worker_state(Distributed.map_pid_wrkr[pid], Distributed.W_TERMINATED)
                                     Distributed.deregister_worker(pid)
                                 end
-                            catch
+                            catch e
+                                @error "error during worker deregistration for pid=$pid" exception=e
                             finally
                                 unlock(Distributed.worker_lock)
                             end
+                        else
+                            @warn "preempt loop for pid=$pid exited with unexpected exception" exception=e
                         end
                     end
                 end
@@ -1216,6 +1219,30 @@ struct SpotPreemptException <: Exception
     instanceid::String
     clusterid::Int
     notbefore::String
+end
+
+"""
+    _extract_preempt_exception(e)
+
+Walk an exception chain to find a SpotPreemptException, regardless of how
+it is wrapped (RemoteException, TaskFailedException, etc.). Returns the
+SpotPreemptException if found, or nothing.
+"""
+function _extract_preempt_exception(e)
+    e isa SpotPreemptException && return e
+    if e isa RemoteException
+        return _extract_preempt_exception(e.captured.ex)
+    end
+    if e isa TaskFailedException && isdefined(e, :task) && istaskdone(e.task) && e.task.result isa Exception
+        return _extract_preempt_exception(e.task.result)
+    end
+    if hasproperty(e, :captured) && e.captured isa CapturedException
+        return _extract_preempt_exception(e.captured.ex)
+    end
+    if e isa CapturedException
+        return _extract_preempt_exception(e.ex)
+    end
+    return nothing
 end
 Base.showerror(io::IO, e::SpotPreemptException) = print(io, "spot preemption on process '$(e.clusterid)' ($(e.instanceid)), not before '$(e.notbefore)'")
 

--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -711,6 +711,8 @@ function spinner(n_target_workers)
         @warn "error during startup:"
         logerror(e, Logging.Warn)
     end
+    isatty = isa(stdout, Base.TTY)
+    last_print = starttime
     while nprocs() == 1 || nworkers() != n_target_workers
         try
             elapsed_time = time() - starttime
@@ -718,8 +720,13 @@ function spinner(n_target_workers)
                 _nworkers = nprocs() == 1 ? 0 : nworkers()
                 tic = time()
             end
-            write(stdout, spin(spincount, elapsed_time)*", $_nworkers/$n_target_workers up. $ws\r")
-            flush(stdout)
+            if isatty
+                write(stdout, spin(spincount, elapsed_time)*", $_nworkers/$n_target_workers up. $ws\r")
+                flush(stdout)
+            elseif time() - last_print >= 30
+                @info "$(spin(spincount, elapsed_time)), $_nworkers/$n_target_workers up."
+                last_print = time()
+            end
             spincount = spincount == 4 ? 1 : spincount + 1
             yield()
             sleep(.25)
@@ -729,8 +736,12 @@ function spinner(n_target_workers)
         end
     end
     _nworkers = nprocs() == 1 ? 0 : nworkers()
-    write(stdout, spin(5, elapsed_time)*", $_nworkers/$n_target_workers are running. $ws\r")
-    write(stdout,"\n")
+    if isatty
+        write(stdout, spin(5, elapsed_time)*", $_nworkers/$n_target_workers are running. $ws\r")
+        write(stdout,"\n")
+    else
+        @info "$(spin(5, elapsed_time)), $_nworkers/$n_target_workers are running."
+    end
     nothing
 end
 
@@ -739,7 +750,7 @@ function nthreads_filter(nthreads)
     nthreads_default = length(_nthreads) > 0 ? parse(Int, _nthreads[1]) : 1
     nthreads_interactive = length(_nthreads) > 1 ? parse(Int, _nthreads[2]) : 0
 
-    nthreads_interactive > 0 ? string("$nthreads_default,$nthreads_interactive") : string(nthreads_default)
+    length(_nthreads) > 1 ? string("$nthreads_default,$nthreads_interactive") : string(nthreads_default)
 end
 
 """
@@ -3276,6 +3287,8 @@ function detached_service_wait(vm, custom_environment)
     elapsed_time = 0.0
     tic = starttime - 20
     spincount = 1
+    isatty = isa(stdout, Base.TTY)
+    last_print = starttime
     waitfor = custom_environment ? "Julia package instantiation and COFII detached service" : "COFII detached service"
     while true
         if time() - tic > 5
@@ -3293,15 +3306,24 @@ function detached_service_wait(vm, custom_environment)
             @error "reached timeout ($timeout seconds) while waiting for $waitfor to start."
             throw(DetachedServiceTimeoutException(vm))
         end
-        
-        write(stdout, spin(spincount, elapsed_time)*", waiting for $waitfor on VM, $(vm["name"]):$(vm["port"]), to start.\r")
-        flush(stdout)
+
+        if isatty
+            write(stdout, spin(spincount, elapsed_time)*", waiting for $waitfor on VM, $(vm["name"]):$(vm["port"]), to start.\r")
+            flush(stdout)
+        elseif time() - last_print >= 30
+            @info "$(spin(spincount, elapsed_time)), waiting for $waitfor on VM, $(vm["name"]):$(vm["port"]), to start."
+            last_print = time()
+        end
         spincount = spincount == 4 ? 1 : spincount + 1
-        
+
         sleep(0.5)
     end
-    write(stdout, spin(5, elapsed_time)*", waiting for $waitfor on VM, $(vm["name"]):$(vm["port"]), to start.\r")
-    write(stdout, "\n")
+    if isatty
+        write(stdout, spin(5, elapsed_time)*", waiting for $waitfor on VM, $(vm["name"]):$(vm["port"]), to start.\r")
+        write(stdout, "\n")
+    else
+        @info "$(spin(5, elapsed_time)), waiting for $waitfor on VM, $(vm["name"]):$(vm["port"]), to start."
+    end
 end
 
 const VARIABLE_BUNDLE = Dict()

--- a/test/image.pkr.hcl
+++ b/test/image.pkr.hcl
@@ -54,6 +54,10 @@ variable "azmanagers_version" {
     default = "master"
 }
 
+variable "build_resource_group" {
+    default = ""
+}
+
 packer {
     required_plugins {
         azure = {
@@ -81,13 +85,13 @@ source "azure-arm" "cofii" {
         replication_regions = ["South Central US"]
     }
     shared_image_gallery_timeout = "120m"
-    build_resource_group_name = var.resource_group
+    build_resource_group_name = var.build_resource_group != "" ? var.build_resource_group : var.resource_group
     managed_image_resource_group_name = var.resource_group
     managed_image_name = var.image_name
     managed_image_storage_account_type = "Premium_LRS"
     virtual_network_name = var.virtual_network
     virtual_network_subnet_name = var.virtual_subnet
-    virtual_network_resource_group_name = var.resource_group
+    virtual_network_resource_group_name = var.build_resource_group != "" ? var.build_resource_group : var.resource_group
     private_virtual_network_with_public_ip = true
     ssh_username = "cvx"
 }

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -171,7 +171,24 @@ if VERSION >= v"1.9"
         end
         @test nprocs() < 3
         @info "[$(elapsed())s] spot eviction test: cleaning up..."
-        with_timeout(()->rmprocs(workers()), 120; msg="rmprocs")
+        try
+            with_timeout(()->rmprocs(workers()), 120; msg="rmprocs")
+        catch
+            # Workers may be unreachable after eviction — force-deregister
+            @warn "[$(elapsed())s] spot eviction test: rmprocs timed out, force-deregistering workers..."
+            for pid in workers()
+                try
+                    lock(Distributed.worker_lock)
+                    if haskey(Distributed.map_pid_wrkr, pid)
+                        Distributed.set_worker_state(Distributed.map_pid_wrkr[pid], Distributed.W_TERMINATED)
+                        Distributed.deregister_worker(pid)
+                    end
+                catch
+                finally
+                    unlock(Distributed.worker_lock)
+                end
+            end
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,18 @@
 using Distributed, AzManagers, Random, TOML, Test, HTTP, AzSessions, JSON, Pkg
 using MPI
 
+function with_timeout(f, seconds; msg="operation")
+    t = @async f()
+    deadline = time() + seconds
+    while !istaskdone(t) && time() < deadline
+        sleep(1)
+    end
+    if !istaskdone(t)
+        error("$msg timed out after $(seconds)s")
+    end
+    fetch(t)
+end
+
 session = AzSession(;protocal=AzClientCredentials)
 
 azmanagers_pinfo = Pkg.project()
@@ -86,7 +98,7 @@ or configure user-defined routes (UDR) in the subnet. Learn more at aka.ms/defau
     @test _r.status == 200
 
     @info "Deleting cluster..."
-    rmprocs(workers())
+    with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
 
     # Last, verify that the scale set has been deleted
     itry = 0
@@ -119,7 +131,7 @@ end
     if VERSION >= v"1.9"
         @test remotecall_fetch(Threads.nthreads, workers()[1], :interactive) == 0
     end
-    rmprocs(workers())
+    with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
 
     group = "test$(randstring('a':'z',4))"
     julia_num_threads = VERSION >= v"1.9" ? "2,0" : "2"
@@ -132,7 +144,7 @@ end
             @test remotecall_fetch(Threads.nthreads, workers()[1], :interactive) == 1
         end
     end
-    rmprocs(workers())
+    with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
 
     group = "test$(randstring('a':'z',4))"
     julia_num_threads = VERSION >= v"1.9" ? "3,2" : "3"
@@ -143,7 +155,7 @@ end
     if VERSION >= v"1.9"
         @test remotecall_fetch(Threads.nthreads, workers()[1], :interactive) == 2
     end
-    rmprocs(workers())
+    with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
 end
 
 if VERSION >= v"1.9"
@@ -163,7 +175,7 @@ if VERSION >= v"1.9"
             sleep(10)
         end
         @test nprocs() < 3
-        rmprocs(workers())
+        with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
     end
 end
 
@@ -202,7 +214,7 @@ end
             sleep(10)
         end
     end
-    wait(testjob)
+    with_timeout(300; msg="wait(testjob)") do wait(testjob) end
     testjob_stdout = read(testjob)
     @test contains(testjob_stdout, "myproject")
 
@@ -211,7 +223,7 @@ end
     @test contains(testjob_stdout, "Manifest.toml")
     @test contains(testjob_stdout, "Project.toml")
 
-    rmproc(testvm; session=session)
+    with_timeout(120; msg="rmproc") do rmproc(testvm; session=session) end
 end
 
 @testset "environment, addprocs" begin
@@ -240,7 +252,7 @@ end
     @test "Project.toml" ∈ files
     @test "Manifest.toml" ∈ files
 
-    rmprocs(workers())
+    with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
 
 end
 
@@ -278,7 +290,7 @@ end
     r = JSON.parse(String(_r.body))
     @test r["tags"]["foo"] == "bar"
 
-    rmprocs(workers())
+    with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
 end
 
 @testset "AzManagers, addproc, and test if nthreads propagates properly" begin
@@ -289,20 +301,20 @@ end
         write(stdout, "write to stdout\n")
         write(stderr, "nthreads: $(Threads.nthreads()),$(Threads.nthreads(:interactive))\n")
     end
-    wait(testjob)
+    with_timeout(300; msg="wait(testjob)") do wait(testjob) end
     @test read(testjob) == "write to stdout\n"
     @test read(testjob; stdio=stderr) == "nthreads: 1,2\n"
-    rmproc(testvm; session=session)
+    with_timeout(120; msg="rmproc") do rmproc(testvm; session=session) end
 
     testvm = addproc(templatename, name=basename, session=session)
     testjob = @detachat testvm begin
         write(stdout, "write to stdout\n")
         write(stderr, "write to stderr\n")
     end
-    wait(testjob)
+    with_timeout(300; msg="wait(testjob)") do wait(testjob) end
     @test read(testjob) == "write to stdout\n"
     @test read(testjob; stdio=stderr) == "write to stderr\n"
-    rmproc(testvm; session=session)
+    with_timeout(120; msg="rmproc") do rmproc(testvm; session=session) end
 end
 
 @testset "AzManagers, detach" for kwargs in ( (dummy="dummy"), )
@@ -324,8 +336,8 @@ end
     end
 
     # Wait for jobs to finish
-    wait(job1)
-    wait(job2)
+    with_timeout(300; msg="wait(job1)") do wait(job1) end
+    with_timeout(300; msg="wait(job2)") do wait(job2) end
 
     @test status(job1) == "done"
     @test read(job1;stdio=stdout) == "job1 - stdout string"
@@ -338,7 +350,7 @@ end
     #
     # Unit Test 3 - shut-down the detached server
     #
-    rmproc(job1.vm; session=session)
+    with_timeout(120; msg="rmproc") do rmproc(job1.vm; session=session) end
 
     #
     # Unit Test 4 - create a new job on a new detached server that auto-destructs upon completion of its work
@@ -359,7 +371,7 @@ end
             write(stdout, "failed")
         end
     end
-    wait(testjob)
+    with_timeout(300; msg="wait(testjob)") do wait(testjob) end
     @test contains(read(testjob), "passed")
 end
 
@@ -392,7 +404,7 @@ end
     end
 
     @info "Deleting cluster..."
-    rmprocs(workers())
+    with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
 
 end
 
@@ -410,7 +422,7 @@ end
     name = r["physical_hostname"]
     @test name !== "unknown" && match(r"[A-Z0-9]", name) !== nothing
 
-    rmproc(testvm; session=session)
+    with_timeout(120; msg="rmproc") do rmproc(testvm; session=session) end
 end
 
 @testset "AzManagers, nphysical_cores $machine_name" for machine_name in ("cbox96","cbox64","ussc/t107/v4/amd/cbox176")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,9 @@ function with_timeout(f, seconds; msg="operation")
     fetch(t)
 end
 
+const test_start_time = time()
+elapsed() = round(time() - test_start_time; digits=1)
+
 session = AzSession(;protocal=AzClientCredentials)
 
 azmanagers_pinfo = Pkg.project()
@@ -34,14 +37,12 @@ or configure user-defined routes (UDR) in the subnet. Learn more at aka.ms/defau
 @testset "AzManagers, addprocs, ppi=$ppi, flexible=$flexible" for ppi in (1,), flexible in (false,#=true=#)
     ninstances = 4
     group = "test$(randstring('a':'z',4))"
-    
+
     # Set up iteration vars
     url = "https://management.azure.com/subscriptions/$subscriptionid/resourceGroups/$resourcegroup/providers/Microsoft.Compute/virtualMachineScaleSets/$group?api-version=2019-12-01"
     tppi = ppi*ninstances                       # Total number of Julia processes in the entire scale set
 
-    #
-    # Unit Test 1 - Create scale set and start Julia processes
-    #
+    @info "[$(elapsed())s] addprocs test: provisioning $ninstances instances (ppi=$ppi, flexible=$flexible, group=$group)..."
     if flexible
         addprocs(templatename, ninstances;
             waitfor = true,
@@ -57,47 +58,33 @@ or configure user-defined routes (UDR) in the subnet. Learn more at aka.ms/defau
             group,
             session)
     end
-    
+    @info "[$(elapsed())s] addprocs test: cluster up, $(nworkers()) workers running"
+
     # Verify that the scale set is present
     _r = HTTP.request("GET", url, Dict("Authorization"=>"Bearer $(token(session))"); verbose=0)
     @test _r.status == 200
 
-    #
-    # Unit Test 2 - Verify that (Total # of Julia processes specified) == (Total # of Julia processes actual)
-    #
     @test nworkers() == tppi
 
-    #
-    # Unit Test 3 - Verify that there is a healthy connection to each node
-    #
     myworkers = [remotecall_fetch(gethostname, workers()[i]) for i=1:tppi]
 
-    #
-    # Unit Test 4 - Verify that none of the created Julia processes are the master Julia process
-    #
     master = gethostname()
     unique_workers = unique(myworkers)
 
     @test length(unique_workers) == ninstances
-    for worker in myworkers 
+    for worker in myworkers
         @test master != worker
     end
 
-    #
-    # Unit Test 5 - Verify that the cloud-init startup script ran successfully
-    #
     for i = 1:tppi
         @test_broken remotecall_fetch(isfile, workers()[i], ".git-credentials")
     end
 
-    #
-    # Unit Test 6 - Delete the Julia processes, scale set instances and the scale set itself
-    #
     # First, verify that the scale set is present
     _r = HTTP.request("GET", url, Dict("Authorization"=>"Bearer $(token(session))"); verbose=0)
     @test _r.status == 200
 
-    @info "Deleting cluster..."
+    @info "[$(elapsed())s] addprocs test: deleting cluster..."
     with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
 
     # Last, verify that the scale set has been deleted
@@ -109,11 +96,11 @@ or configure user-defined routes (UDR) in the subnet. Learn more at aka.ms/defau
         catch _e
             e = JSON.parse(String(_e.response.body))
             if _e.status == 404 && e["error"]["code"] == "ResourceNotFound"
-                @info "Cluster deleted!"
+                @info "[$(elapsed())s] addprocs test: cluster deleted"
                 break
             end
             if itry == 10
-                @warn "cluster not deleted"
+                @warn "[$(elapsed())s] addprocs test: cluster not deleted after $itry attempts"
                 break
             end
         end
@@ -122,6 +109,7 @@ or configure user-defined routes (UDR) in the subnet. Learn more at aka.ms/defau
 end
 
 @testset "addprocs, spot" begin
+    @info "[$(elapsed())s] spot test: provisioning 1 instance (threads=2,0, spot=false)..."
     group = "test$(randstring('a':'z',4))"
     julia_num_threads = VERSION >= v"1.9" ? "2,0" : "2"
     addprocs(templatename, 1; waitfor = true, group, session, julia_num_threads)
@@ -131,8 +119,10 @@ end
     if VERSION >= v"1.9"
         @test remotecall_fetch(Threads.nthreads, workers()[1], :interactive) == 0
     end
+    @info "[$(elapsed())s] spot test: cleaning up non-spot workers..."
     with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
 
+    @info "[$(elapsed())s] spot test: provisioning 1 instance (threads=2,0, spot=true)..."
     group = "test$(randstring('a':'z',4))"
     julia_num_threads = VERSION >= v"1.9" ? "2,0" : "2"
     addprocs(templatename, 1; waitfor = true, group, session, julia_num_threads, spot = true)
@@ -144,8 +134,10 @@ end
             @test remotecall_fetch(Threads.nthreads, workers()[1], :interactive) == 1
         end
     end
+    @info "[$(elapsed())s] spot test: cleaning up spot workers..."
     with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
 
+    @info "[$(elapsed())s] spot test: provisioning 1 instance (threads=3,2, spot=true)..."
     group = "test$(randstring('a':'z',4))"
     julia_num_threads = VERSION >= v"1.9" ? "3,2" : "3"
     addprocs(templatename, 1; waitfor = true, group, session, julia_num_threads, spot=true)
@@ -155,31 +147,36 @@ end
     if VERSION >= v"1.9"
         @test remotecall_fetch(Threads.nthreads, workers()[1], :interactive) == 2
     end
+    @info "[$(elapsed())s] spot test: cleaning up..."
     with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
 end
 
 if VERSION >= v"1.9"
     @testset "spot eviction" begin
+        @info "[$(elapsed())s] spot eviction test: provisioning 2 instances..."
         group = "test$(randstring('a':'z',4))"
         julia_num_threads = "2,1"
         addprocs(templatename, 2; waitfor = true, group, session, julia_num_threads, spot = true)
 
+        @info "[$(elapsed())s] spot eviction test: simulating eviction on worker $(workers()[1])..."
         AzManagers.simulate_spot_eviction(workers()[1])
 
         tic = time()
         while time() - tic < 300
             if nprocs() < 3
-                @info "cluster responded to spot eviction in $(time() - tic) seconds"
+                @info "[$(elapsed())s] spot eviction test: cluster responded in $(round(time() - tic; digits=1))s"
                 break
             end
             sleep(10)
         end
         @test nprocs() < 3
+        @info "[$(elapsed())s] spot eviction test: cleaning up..."
         with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
     end
 end
 
 @testset "environment, addproc" begin
+    @info "[$(elapsed())s] environment addproc test: setting up project..."
     mkpath("myproject")
     cd("myproject")
     Pkg.activate(".")
@@ -189,13 +186,16 @@ end
     Pkg.add("HTTP")
 
     Pkg.add(PackageSpec(name="AzManagers", rev=azmanagers_rev))
+    @info "[$(elapsed())s] environment addproc test: project setup complete"
 
     write("LocalPreferences.toml", "[FooPackage]\nfoo = \"bar\"\n")
 
     r = randstring('a':'z',4)
     bname = "test$r"
 
+    @info "[$(elapsed())s] environment addproc test: provisioning VM (customenv=true)..."
     testvm = addproc(templatename; basename=bname, session=session, customenv=true)
+    @info "[$(elapsed())s] environment addproc test: VM ready, running detached job..."
     testjob = nothing
     for attempt in 1:5
         try
@@ -210,10 +210,11 @@ end
             if attempt == 5
                 rethrow()
             end
-            @warn "detachat attempt $attempt failed, retrying in 10s..." exception=e
+            @warn "[$(elapsed())s] environment addproc test: detachat attempt $attempt failed, retrying in 10s..." exception=e
             sleep(10)
         end
     end
+    @info "[$(elapsed())s] environment addproc test: waiting for detached job..."
     with_timeout(300; msg="wait(testjob)") do wait(testjob) end
     testjob_stdout = read(testjob)
     @test contains(testjob_stdout, "myproject")
@@ -223,10 +224,12 @@ end
     @test contains(testjob_stdout, "Manifest.toml")
     @test contains(testjob_stdout, "Project.toml")
 
+    @info "[$(elapsed())s] environment addproc test: cleaning up..."
     with_timeout(120; msg="rmproc") do rmproc(testvm; session=session) end
 end
 
 @testset "environment, addprocs" begin
+    @info "[$(elapsed())s] environment addprocs test: setting up project..."
     mkpath("myproject")
     cd("myproject")
     Pkg.activate(".")
@@ -238,10 +241,13 @@ end
     write("LocalPreferences.toml", "[FooPackage]\nfoo = \"bar\"\n")
 
     Pkg.add(PackageSpec(name="AzManagers", rev=azmanagers_rev))
+    @info "[$(elapsed())s] environment addprocs test: project setup complete"
 
     group = "test$(randstring('a':'z',4))"
 
+    @info "[$(elapsed())s] environment addprocs test: provisioning 1 instance (customenv=true)..."
     addprocs(templatename, 1; waitfor=true, group=group, session=session, customenv=true)
+    @info "[$(elapsed())s] environment addprocs test: cluster up"
     @everywhere using Pkg
     pinfo = remotecall_fetch(Pkg.project, workers()[1])
     @test contains(pinfo.path, "myproject")
@@ -252,11 +258,13 @@ end
     @test "Project.toml" ∈ files
     @test "Manifest.toml" ∈ files
 
+    @info "[$(elapsed())s] environment addprocs test: cleaning up..."
     with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
 
 end
 
 @testset "tags, addprocs" begin
+    @info "[$(elapsed())s] tags test: setting up project..."
     mkpath("myproject")
     cd("myproject")
     Pkg.activate(".")
@@ -279,7 +287,9 @@ end
         _template["tags"] = Dict("foo"=>"bar")
     end
 
+    @info "[$(elapsed())s] tags test: provisioning 1 instance..."
     addprocs(template, 1; waitfor=true, group=group, session=session)
+    @info "[$(elapsed())s] tags test: verifying tags..."
 
     _r = HTTP.request(
         "GET",
@@ -290,13 +300,16 @@ end
     r = JSON.parse(String(_r.body))
     @test r["tags"]["foo"] == "bar"
 
+    @info "[$(elapsed())s] tags test: cleaning up..."
     with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
 end
 
 @testset "AzManagers, addproc, and test if nthreads propagates properly" begin
+    @info "[$(elapsed())s] nthreads test: provisioning VM (threads=1,2)..."
     r = randstring('a':'z',4)
     basename = "test$r"
     testvm = addproc(templatename; basename=basename, session=session, julia_num_threads="1,2")
+    @info "[$(elapsed())s] nthreads test: VM ready, running detached job..."
     testjob = @detachat testvm begin
         write(stdout, "write to stdout\n")
         write(stderr, "nthreads: $(Threads.nthreads()),$(Threads.nthreads(:interactive))\n")
@@ -304,9 +317,12 @@ end
     with_timeout(300; msg="wait(testjob)") do wait(testjob) end
     @test read(testjob) == "write to stdout\n"
     @test read(testjob; stdio=stderr) == "nthreads: 1,2\n"
+    @info "[$(elapsed())s] nthreads test: cleaning up first VM..."
     with_timeout(120; msg="rmproc") do rmproc(testvm; session=session) end
 
+    @info "[$(elapsed())s] nthreads test: provisioning VM (reusing name=$basename)..."
     testvm = addproc(templatename, name=basename, session=session)
+    @info "[$(elapsed())s] nthreads test: VM ready, running detached job..."
     testjob = @detachat testvm begin
         write(stdout, "write to stdout\n")
         write(stderr, "write to stderr\n")
@@ -314,28 +330,25 @@ end
     with_timeout(300; msg="wait(testjob)") do wait(testjob) end
     @test read(testjob) == "write to stdout\n"
     @test read(testjob; stdio=stderr) == "write to stderr\n"
+    @info "[$(elapsed())s] nthreads test: cleaning up..."
     with_timeout(120; msg="rmproc") do rmproc(testvm; session=session) end
 end
 
 @testset "AzManagers, detach" for kwargs in ( (dummy="dummy"), )
 
-    #
-    # Unit Test 1 - Create a detached job and persist the server
-    #
+    @info "[$(elapsed())s] detach test: creating persistent detached job..."
     job1 = @detach vm(;vm_template=templatename, session=session, persist=true) begin
         write(stdout, "job1 - stdout string")
         write(stderr, "job1 - stderr string")
     end
 
-    #
-    # Unit Test 2 - Send a new job to the server started above
-    #
+    @info "[$(elapsed())s] detach test: sending second job to same server..."
     job2 = @detachat job1.vm begin
         write(stdout, "job2 - stdout string")
         write(stderr, "job2 - stderr string")
     end
 
-    # Wait for jobs to finish
+    @info "[$(elapsed())s] detach test: waiting for jobs..."
     with_timeout(300; msg="wait(job1)") do wait(job1) end
     with_timeout(300; msg="wait(job2)") do wait(job2) end
 
@@ -347,23 +360,21 @@ end
     @test read(job2;stdio=stdout) == "job2 - stdout string"
     @test read(job2;stdio=stderr) == "job2 - stderr string"
 
-    #
-    # Unit Test 3 - shut-down the detached server
-    #
+    @info "[$(elapsed())s] detach test: shutting down detached server..."
     with_timeout(120; msg="rmproc") do rmproc(job1.vm; session=session) end
 
-    #
-    # Unit Test 4 - create a new job on a new detached server that auto-destructs upon completion of its work
-    #
+    @info "[$(elapsed())s] detach test: creating auto-destruct detached job..."
     job3 = @detach vm(;vm_template=templatename, session=session, persist=false) begin
     end
 end
 
 @testset "AzManagers, detach, variablebundle" begin
+    @info "[$(elapsed())s] variablebundle test: provisioning VM..."
     r = randstring('a':'z',4)
     basename = "test$r"
     testvm = addproc(templatename; basename=basename, session=session)
     variablebundle!(a=1.0,b=3.14)
+    @info "[$(elapsed())s] variablebundle test: running detached job..."
     testjob = @detachat testvm begin
         if variablebundle(:a) ≈ 1.0 && variablebundle(:b) ≈ 3.14
             write(stdout, "passed")
@@ -376,6 +387,7 @@ end
 end
 
 @testset "AzManagers, retrywarn" begin
+    @info "[$(elapsed())s] retrywarn test: testing retry warning output..."
     r = HTTP.Response(
         429,
         ["retry-after"=>60, "x-ms-ratelimit-remaining-resource"=>"foo"],
@@ -386,29 +398,31 @@ end
 end
 
 @testset "AzManagers, physical_hostname" begin
-
+    @info "[$(elapsed())s] physical_hostname test: provisioning 2 instances..."
     group = "test$(randstring('a':'z',4))"
 
     templates_scaleset = JSON.parse(read(AzManagers.templates_filename_scaleset(), String))
     template = templates_scaleset[templatename]
-    
+
     addprocs(template, 2; waitfor=true, group=group, session=session)
+    @info "[$(elapsed())s] physical_hostname test: cluster up, checking hostnames..."
 
     wrkers = Distributed.map_pid_wrkr
     for i in workers()
-        userdata = wrkers[i].config.userdata 
+        userdata = wrkers[i].config.userdata
         @info userdata
         name = get(userdata, "physical_hostname", "unknown")
 
         @test name !== "unknown" && match(r"[A-Z0-9]", name) !== nothing
     end
 
-    @info "Deleting cluster..."
+    @info "[$(elapsed())s] physical_hostname test: cleaning up..."
     with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
 
 end
 
 @testset "AzManagers, addproc physical_hostname" begin
+    @info "[$(elapsed())s] addproc physical_hostname test: provisioning VM..."
     r = randstring('a':'z',4)
     basename = "test$r"
     testvm = addproc(templatename; basename=basename, session=session)
@@ -422,10 +436,12 @@ end
     name = r["physical_hostname"]
     @test name !== "unknown" && match(r"[A-Z0-9]", name) !== nothing
 
+    @info "[$(elapsed())s] addproc physical_hostname test: cleaning up..."
     with_timeout(120; msg="rmproc") do rmproc(testvm; session=session) end
 end
 
 @testset "AzManagers, nphysical_cores $machine_name" for machine_name in ("cbox96","cbox64","ussc/t107/v4/amd/cbox176")
+    @info "[$(elapsed())s] nphysical_cores test: checking $machine_name..."
     ncores = nphysical_cores(machine_name)
 
     if machine_name == "cbox96"
@@ -438,8 +454,9 @@ end
 end
 
 @testset "AzManagers, nphysical_cores $templatename"
+    @info "[$(elapsed())s] nphysical_cores template test: checking $templatename..."
     templates_scaleset = JSON.parse(read(AzManagers.templates_filename_vm(), String))
-    template = templates_vm[templatename] 
+    template = templates_vm[templatename]
     ncores = nphysical_cores(template)
 
     @test ncores == 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,7 +85,7 @@ or configure user-defined routes (UDR) in the subnet. Learn more at aka.ms/defau
     @test _r.status == 200
 
     @info "[$(elapsed())s] addprocs test: deleting cluster..."
-    with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
+    with_timeout(()->rmprocs(workers()), 120; msg="rmprocs")
 
     # Last, verify that the scale set has been deleted
     itry = 0
@@ -120,7 +120,7 @@ end
         @test remotecall_fetch(Threads.nthreads, workers()[1], :interactive) == 0
     end
     @info "[$(elapsed())s] spot test: cleaning up non-spot workers..."
-    with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
+    with_timeout(()->rmprocs(workers()), 120; msg="rmprocs")
 
     @info "[$(elapsed())s] spot test: provisioning 1 instance (threads=2,0, spot=true)..."
     group = "test$(randstring('a':'z',4))"
@@ -135,7 +135,7 @@ end
         end
     end
     @info "[$(elapsed())s] spot test: cleaning up spot workers..."
-    with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
+    with_timeout(()->rmprocs(workers()), 120; msg="rmprocs")
 
     @info "[$(elapsed())s] spot test: provisioning 1 instance (threads=3,2, spot=true)..."
     group = "test$(randstring('a':'z',4))"
@@ -148,7 +148,7 @@ end
         @test remotecall_fetch(Threads.nthreads, workers()[1], :interactive) == 2
     end
     @info "[$(elapsed())s] spot test: cleaning up..."
-    with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
+    with_timeout(()->rmprocs(workers()), 120; msg="rmprocs")
 end
 
 if VERSION >= v"1.9"
@@ -171,7 +171,7 @@ if VERSION >= v"1.9"
         end
         @test nprocs() < 3
         @info "[$(elapsed())s] spot eviction test: cleaning up..."
-        with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
+        with_timeout(()->rmprocs(workers()), 120; msg="rmprocs")
     end
 end
 
@@ -215,7 +215,7 @@ end
         end
     end
     @info "[$(elapsed())s] environment addproc test: waiting for detached job..."
-    with_timeout(300; msg="wait(testjob)") do wait(testjob) end
+    with_timeout(()->wait(testjob), 300; msg="wait(testjob)")
     testjob_stdout = read(testjob)
     @test contains(testjob_stdout, "myproject")
 
@@ -225,7 +225,7 @@ end
     @test contains(testjob_stdout, "Project.toml")
 
     @info "[$(elapsed())s] environment addproc test: cleaning up..."
-    with_timeout(120; msg="rmproc") do rmproc(testvm; session=session) end
+    with_timeout(()->rmproc(testvm; session=session), 120; msg="rmproc")
 end
 
 @testset "environment, addprocs" begin
@@ -259,7 +259,7 @@ end
     @test "Manifest.toml" ∈ files
 
     @info "[$(elapsed())s] environment addprocs test: cleaning up..."
-    with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
+    with_timeout(()->rmprocs(workers()), 120; msg="rmprocs")
 
 end
 
@@ -301,7 +301,7 @@ end
     @test r["tags"]["foo"] == "bar"
 
     @info "[$(elapsed())s] tags test: cleaning up..."
-    with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
+    with_timeout(()->rmprocs(workers()), 120; msg="rmprocs")
 end
 
 @testset "AzManagers, addproc, and test if nthreads propagates properly" begin
@@ -314,11 +314,11 @@ end
         write(stdout, "write to stdout\n")
         write(stderr, "nthreads: $(Threads.nthreads()),$(Threads.nthreads(:interactive))\n")
     end
-    with_timeout(300; msg="wait(testjob)") do wait(testjob) end
+    with_timeout(()->wait(testjob), 300; msg="wait(testjob)")
     @test read(testjob) == "write to stdout\n"
     @test read(testjob; stdio=stderr) == "nthreads: 1,2\n"
     @info "[$(elapsed())s] nthreads test: cleaning up first VM..."
-    with_timeout(120; msg="rmproc") do rmproc(testvm; session=session) end
+    with_timeout(()->rmproc(testvm; session=session), 120; msg="rmproc")
 
     @info "[$(elapsed())s] nthreads test: provisioning VM (reusing name=$basename)..."
     testvm = addproc(templatename, name=basename, session=session)
@@ -327,11 +327,11 @@ end
         write(stdout, "write to stdout\n")
         write(stderr, "write to stderr\n")
     end
-    with_timeout(300; msg="wait(testjob)") do wait(testjob) end
+    with_timeout(()->wait(testjob), 300; msg="wait(testjob)")
     @test read(testjob) == "write to stdout\n"
     @test read(testjob; stdio=stderr) == "write to stderr\n"
     @info "[$(elapsed())s] nthreads test: cleaning up..."
-    with_timeout(120; msg="rmproc") do rmproc(testvm; session=session) end
+    with_timeout(()->rmproc(testvm; session=session), 120; msg="rmproc")
 end
 
 @testset "AzManagers, detach" for kwargs in ( (dummy="dummy"), )
@@ -349,8 +349,8 @@ end
     end
 
     @info "[$(elapsed())s] detach test: waiting for jobs..."
-    with_timeout(300; msg="wait(job1)") do wait(job1) end
-    with_timeout(300; msg="wait(job2)") do wait(job2) end
+    with_timeout(()->wait(job1), 300; msg="wait(job1)")
+    with_timeout(()->wait(job2), 300; msg="wait(job2)")
 
     @test status(job1) == "done"
     @test read(job1;stdio=stdout) == "job1 - stdout string"
@@ -361,7 +361,7 @@ end
     @test read(job2;stdio=stderr) == "job2 - stderr string"
 
     @info "[$(elapsed())s] detach test: shutting down detached server..."
-    with_timeout(120; msg="rmproc") do rmproc(job1.vm; session=session) end
+    with_timeout(()->rmproc(job1.vm; session=session), 120; msg="rmproc")
 
     @info "[$(elapsed())s] detach test: creating auto-destruct detached job..."
     job3 = @detach vm(;vm_template=templatename, session=session, persist=false) begin
@@ -382,7 +382,7 @@ end
             write(stdout, "failed")
         end
     end
-    with_timeout(300; msg="wait(testjob)") do wait(testjob) end
+    with_timeout(()->wait(testjob), 300; msg="wait(testjob)")
     @test contains(read(testjob), "passed")
 end
 
@@ -417,7 +417,7 @@ end
     end
 
     @info "[$(elapsed())s] physical_hostname test: cleaning up..."
-    with_timeout(120; msg="rmprocs") do rmprocs(workers()) end
+    with_timeout(()->rmprocs(workers()), 120; msg="rmprocs")
 
 end
 
@@ -437,7 +437,7 @@ end
     @test name !== "unknown" && match(r"[A-Z0-9]", name) !== nothing
 
     @info "[$(elapsed())s] addproc physical_hostname test: cleaning up..."
-    with_timeout(120; msg="rmproc") do rmproc(testvm; session=session) end
+    with_timeout(()->rmproc(testvm; session=session), 120; msg="rmproc")
 end
 
 @testset "AzManagers, nphysical_cores $machine_name" for machine_name in ("cbox96","cbox64","ussc/t107/v4/amd/cbox176")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -184,11 +184,23 @@ end
     bname = "test$r"
 
     testvm = addproc(templatename; basename=bname, session=session, customenv=true)
-    testjob = @detachat testvm begin
-        using Pkg
-        pinfo = Pkg.project()
-        write(stdout, "project path is $(dirname(pinfo.path))\n")
-        write(stdout, "$(readdir(dirname(pinfo.path)))")
+    testjob = nothing
+    for attempt in 1:5
+        try
+            testjob = @detachat testvm begin
+                using Pkg
+                pinfo = Pkg.project()
+                write(stdout, "project path is $(dirname(pinfo.path))\n")
+                write(stdout, "$(readdir(dirname(pinfo.path)))")
+            end
+            break
+        catch e
+            if attempt == 5
+                rethrow()
+            end
+            @warn "detachat attempt $attempt failed, retrying in 10s..." exception=e
+            sleep(10)
+        end
     end
     wait(testjob)
     testjob_stdout = read(testjob)

--- a/test/templates.jl
+++ b/test/templates.jl
@@ -6,6 +6,7 @@ resourcegroup = ENV["RESOURCE_GROUP"]
 client_id = ENV["CLIENT_ID"]
 client_secret = ENV["CLIENT_SECRET"]
 imagename = ENV["IMAGE_NAME"]
+gallery_rg = get(ENV, "GALLERY_RG", resourcegroup)
 
 templatename = "cbox02"
 
@@ -16,6 +17,7 @@ sstemplate = AzManagers.build_sstemplate(
         location             = "southcentralus",
         resourcegroup        = resourcegroup,
         resourcegroup_vnet   = resourcegroup,
+        resourcegroup_image  = gallery_rg,
         vnet                 = ENV["VNET_NAME"],
         subnet               = ENV["SUBNET_NAME"],
         imagegallery         = ENV["GALLERY_NAME"],
@@ -42,6 +44,7 @@ vmtemplate = AzManagers.build_vmtemplate(
         location             = "southcentralus",
         resourcegroup        = resourcegroup,
         resourcegroup_vnet   = resourcegroup,
+        resourcegroup_image  = gallery_rg,
         imagegallery         = ENV["GALLERY_NAME"],
         imagename            = imagename,
         vmsize               = "Standard_D2s_v5")


### PR DESCRIPTION
## Summary
- CI was sporadically failing with `ssh: connect to host ... port 22: Connection refused` because the coordinator VM's SSH wasn't ready immediately after `az vm create`
- Added a retry loop (up to 30 attempts, 10s apart) that waits for SSH to become available before running the test suite

## Test plan
- [ ] Verify CI passes on this PR (the retry loop itself will be exercised)
- [ ] Confirm no change to test behavior — only the wait-for-SSH step is new