### PR TITLE
Fix addprocs type piracy — require AzManager as first argument

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AzManagers"
 uuid = "db05ebb0-6096-11e9-199b-87b703361841"
 authors = ["samtkaplan <sam.kaplan@chevron.com>"]
-version = "3.17.6"
+version = "4.0.0"
 
 [deps]
 AzSessions = "f239b30d-ae6b-58be-a2d5-7e9f30e280a9"

--- a/demo/detached.jl
+++ b/demo/detached.jl
@@ -67,7 +67,7 @@ sessionbundle!(
 
 job4 = @detach vm(;session=sessionbundle(:management),persist=true) begin
     using Distributed, AzManagers, AzStorage, AzSessions
-    addprocs("cbox04", 4; session=sessionbundle(:management))
+    addprocs(AzManager(), "cbox04", 4; session=sessionbundle(:management))
 
     for pid in workers()
         hostname = remotecall_fetch(gethostname, pid)

--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -752,9 +752,10 @@ function nthreads_filter(nthreads)
 end
 
 """
-    addprocs(template, ninstances[; kwargs...])
+    addprocs(mgr::AzManager, template, ninstances[; kwargs...])
 
-Add Azure scale set instances where template is either a dictionary produced via the `AzManagers.build_sstemplate`
+Add Azure scale set instances where `mgr` is an `AzManager` instance (e.g. `AzManager()`),
+and template is either a dictionary produced via the `AzManagers.build_sstemplate`
 method or a string corresponding to a template stored in `~/.azmanagers/templates_scaleset.json.`
 
 # key word arguments:
@@ -803,7 +804,7 @@ used on the Julia workers.  This feature makes use of package extensions, meanin
 that `using MPI` is somewhere in your calling script.
 [5] This may result in a re-boot of the VMs
 """
-function Distributed.addprocs(template::Dict, n::Int;
+function Distributed.addprocs(_::AzManager, template::Dict, n::Int;
         subscriptionid = "",
         resourcegroup = "",
         sigimagename = "",
@@ -872,13 +873,13 @@ function Distributed.addprocs(template::Dict, n::Int;
     nothing
 end
 
-function Distributed.addprocs(template::AbstractString, n::Int; kwargs...)
+function Distributed.addprocs(mgr::AzManager, template::AbstractString, n::Int; kwargs...)
     isfile(templates_filename_scaleset()) || error("scale-set template file does not exist.  See `AzManagers.save_template_scaleset`")
 
     templates_scaleset = JSON.parse(read(templates_filename_scaleset(), String); dicttype=Dict)
     haskey(templates_scaleset, template) || error("scale-set template file does not contain a template with name: $template. See `AzManagers.save_template_scaleset`")
 
-    addprocs(templates_scaleset[template], n; kwargs...)
+    addprocs(mgr, templates_scaleset[template], n; kwargs...)
 end
 
 function Distributed.launch(manager::AzManager, params::Dict, launched::Array, c::Condition)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,7 @@ or configure user-defined routes (UDR) in the subnet. Learn more at aka.ms/defau
     # Unit Test 1 - Create scale set and start Julia processes
     #
     if flexible
-        addprocs(templatename, ninstances;
+        addprocs(AzManager(), templatename, ninstances;
             waitfor = true,
             ppi,
             group,
@@ -39,7 +39,7 @@ or configure user-defined routes (UDR) in the subnet. Learn more at aka.ms/defau
             spot = true,
             spot_base_regular_priority_count = 2)
     else
-        addprocs(templatename, ninstances;
+        addprocs(AzManager(), templatename, ninstances;
             waitfor = true,
             ppi,
             group,


### PR DESCRIPTION
## Summary

Fixes type piracy in `addprocs` by requiring an `AzManager` instance as the first argument, so we dispatch on an owned type instead of `Dict`/`AbstractString`.

## Changes

- `addprocs(template, n; ...)` → `addprocs(mgr::AzManager, template, n; ...)`
- Export `azmanager()` so callers use `addprocs(azmanager(), template, n; ...)`
- Update test and demo callsites

## Motivation

This aligns the AzManagers.jl public API with SchedulingManagers.jl, enabling an adapter pattern where users can swap the resource management backend. The manager-first signature is the standard Julia `ClusterManager` convention and eliminates the type piracy that previously extended `Distributed.addprocs` on non-owned types.