### PR TITLE
fix bug for ppi>1

### DIFF
--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -1486,10 +1486,13 @@ function Distributed.launch_n_additional_processes(manager::AzManager, frompid, 
             wconfig.count = fromconfig.count
             wconfig.userdata = Dict(
                 "localid" => localid+1,
+                "instanceid" => fromconfig.userdata["instanceid"],
+                "physical_hostname" => fromconfig.userdata["physical_hostname"],
                 "name" => fromconfig.userdata["name"],
                 "subscriptionid" => fromconfig.userdata["subscriptionid"],
                 "resourcegroup" => fromconfig.userdata["resourcegroup"],
-                "scalesetname" => fromconfig.userdata["scalesetname"])
+                "scalesetname" => fromconfig.userdata["scalesetname"],
+                "priority" => fromconfig.userdata["priority"])
 
             let wconfig=wconfig
                 @async begin


### PR DESCRIPTION
This fixes a bug where the `kill` method assumes that `instanceid` exists in a workers config in order to check for preemption.  But, for the case of ppi>1, the additional workers on a machine did not have `instanceid` set causing the `kill` method to error when calling `ispreempted`.