### PR TITLE
update worker userdata for ppi>1

### DIFF
--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -1486,10 +1486,13 @@ function Distributed.launch_n_additional_processes(manager::AzManager, frompid, 
             wconfig.count = fromconfig.count
             wconfig.userdata = Dict(
                 "localid" => localid+1,
+                "instanceid" => fromconfig.userdata["instanceid"],
+                "physical_hostname" => fromconfig.userdata["physical_hostname"],
                 "name" => fromconfig.userdata["name"],
                 "subscriptionid" => fromconfig.userdata["subscriptionid"],
                 "resourcegroup" => fromconfig.userdata["resourcegroup"],
-                "scalesetname" => fromconfig.userdata["scalesetname"])
+                "scalesetname" => fromconfig.userdata["scalesetname"],
+                "priority" => fromconfig.userdata["priority"])
 
             let wconfig=wconfig
                 @async begin


### PR DESCRIPTION
same as #195, but for master.  This adds a few more variables to the worker definition for additional workers.