### PR TITLE
Source hardening: bug fixes, telemetry, and dev-package guard

### DIFF
--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -2,8 +2,8 @@ module AzManagers
 
 using AzSessions, Base64, CodecZlib, Dates, Distributed, HTTP, JSON, JWTs, LibCURL, LibGit2, Logging, Pkg, Printf, Random, Serialization, Sockets, TOML
 
-include("utilities.jl")
 include("types.jl")
+include("utilities.jl")
 include("templates.jl")
 include("scaleset.jl")
 include("worker.jl")

--- a/src/connections.jl
+++ b/src/connections.jl
@@ -40,6 +40,10 @@ function add_pending_connections()
                 @debug "done pushing new socket onto manger.pending_up" manager.pending_up.n_avail_items
             end
         catch e
+            if !isopen(manager.server)
+                @error "AzManagers, server socket closed — stopping connection listener"
+                break
+            end
             @error "AzManagers, error adding pending connection"
             logerror(e, Logging.Debug)
         end
@@ -107,17 +111,29 @@ function process_pending_connections()
         end
         sockets = TCPSocket[first_socket]
 
-        # Drain additional sockets until deadline or batch full
-        drain_with_deadline!(sockets, manager.pending_up, max_sockets, flush_delay)
+        try
+            # Drain additional sockets until deadline or batch full
+            drain_with_deadline!(sockets, manager.pending_up, max_sockets, flush_delay)
 
-        @debug "flushing batch" length(sockets)
-        pids = addprocs_with_timeout(manager; sockets)
+            @debug "flushing batch" length(sockets)
+            pids = addprocs_with_timeout(manager; sockets)
+            @debug "batch done" pids
 
-        if isdefined(manager, :workers_changed)
-            notify(manager.workers_changed)
+            if isdefined(manager, :workers_changed)
+                lock(manager.workers_changed)
+                try
+                    notify(manager.workers_changed)
+                finally
+                    unlock(manager.workers_changed)
+                end
+            end
+
+            start_preempt_monitors(manager, pids)
+            @debug "loop iteration complete, waiting for next socket"
+        catch e
+            @error "AzManagers, error processing connection batch"
+            logerror(e, Logging.Debug)
         end
-
-        start_preempt_monitors(manager, pids)
     end
 end
 
@@ -145,11 +161,11 @@ function drain_with_deadline!(sockets, pending_up, max_sockets, deadline_s)
 end
 
 function start_preempt_monitors(manager, pids)
-    @debug "starting preempt loops" pids
+    @info "starting preempt monitors" pids
     for pid in pids
         @async monitor_worker_preempt(manager, pid)
     end
-    @debug "done starting preempt loops"
+    @info "preempt monitors launched" pids
 end
 
 function monitor_worker_preempt(manager, pid)
@@ -170,6 +186,8 @@ end
 
 function handle_preempt_exception(manager, pid, wrkr, e)
     if isa(e, RemoteException) && isa(e.captured.ex, TaskFailedException) && isa(e.captured.ex.task.result.ex, SpotPreemptException)
+        # Graceful preemption: IMDS scheduled event was detected before the VM was killed.
+        # Honor the NotBefore window before deregistering.
         ex = e.captured.ex.task.result.ex
         notbefore = DateTime(ex.notbefore, dateformat"e, dd u yyyy HH:MM:SS \G\M\T")
         @info "caught preempt exception for $(ex.clusterid), removing not before $notbefore UTC"
@@ -185,19 +203,26 @@ function handle_preempt_exception(manager, pid, wrkr, e)
         catch e
             @info "error adding instance to preempted list"
         end
-
-        try
-            lock(Distributed.worker_lock)
-            if haskey(Distributed.map_pid_wrkr, pid)
-                # We can't use rmprocs here since the worker process might already be gone due to preemption.  The
-                # worker process would usually do the following two lines (see the Distributed.message_handler_loop function)
-                Distributed.set_worker_state(Distributed.map_pid_wrkr[pid], Distributed.W_TERMINATED)
-                Distributed.deregister_worker(pid)
-            end
-        catch
-        finally
-            unlock(Distributed.worker_lock)
+    else
+        # Worker connection dropped — could be an ungraceful eviction, crash, or
+        # normal cleanup (rmprocs killed the process while preempt monitor was running).
+        # Only warn if the worker is still registered (i.e. not already cleaned up by rmprocs).
+        if haskey(Distributed.map_pid_wrkr, pid)
+            @warn "worker $pid lost unexpectedly (not a graceful preemption), deregistering" exception=(e, catch_backtrace())
         end
+    end
+
+    # Always deregister the worker — whether graceful preemption or unexpected death.
+    try
+        lock(Distributed.worker_lock)
+        if haskey(Distributed.map_pid_wrkr, pid)
+            Distributed.set_worker_state(Distributed.map_pid_wrkr[pid], Distributed.W_TERMINATED)
+            Distributed.deregister_worker(pid)
+        end
+    catch e
+        @error "error deregistering worker $pid" exception=(e, catch_backtrace())
+    finally
+        unlock(Distributed.worker_lock)
     end
 end
 
@@ -254,10 +279,19 @@ end
 
 
 function spinner(n_target_workers)
+    timeout = parse(Int, get(ENV, "JULIA_WORKER_TIMEOUT", "720")) + 120
     manager = azmanager()
     starttime = time()
 
     while (nprocs() == 1 ? 0 : nworkers()) != n_target_workers
+        elapsed = time() - starttime
+        if elapsed > timeout
+            n = nprocs() == 1 ? 0 : nworkers()
+            @printf(stdout, "\r  %d/%d workers up (%.1fs) — timed out\n", n, n_target_workers, elapsed)
+            flush(stdout)
+            error("Timed out after $(round(elapsed, digits=1))s waiting for workers: $n/$n_target_workers up. Consider increasing JULIA_WORKER_TIMEOUT.")
+        end
+
         # Wait for workers_changed notification with a timeout for UI updates
         tsk = @async begin
             lock(manager.workers_changed)
@@ -384,7 +418,7 @@ function Distributed.addprocs(::AzManager, template::Dict, n::Int;
     user == "" && (user = _manifest["ssh_user"])
 
     manager = azmanager!(session, user, nretry, verbose, save_cloud_init_failures, show_quota)
-    sigimagename,sigimageversion,imagename = scaleset_image(manager, sigimagename, sigimageversion, imagename)
+    sigimagename,sigimageversion,imagename = scaleset_image(manager, sigimagename, sigimageversion, imagename, template["value"])
     scaleset_image!(manager, template["value"], sigimagename, sigimageversion, imagename)
     software_sanity_check(manager, imagename == "" ? sigimagename : imagename, customenv)
 

--- a/src/detached.jl
+++ b/src/detached.jl
@@ -88,7 +88,7 @@ function addproc(vm_template::Dict, nic_template=nothing;
     subnetid = vm_template["value"]["properties"]["networkProfile"]["networkInterfaces"][1]["id"]
 
     @debug "getting image info"
-    sigimagename, sigimageversion, imagename = scaleset_image(manager, sigimagename, sigimageversion, imagename)
+    sigimagename, sigimageversion, imagename = scaleset_image(manager, sigimagename, sigimageversion, imagename, vm_template["value"])
     scaleset_image!(manager, vm_template["value"], sigimagename, sigimageversion, imagename)
 
     vm_template["value"]["properties"]["storageProfile"]["osDisk"]["diskSizeGB"] = max(osdisksize, image_osdisksize(manager, vm_template["value"], sigimagename, sigimageversion, imagename))
@@ -487,6 +487,7 @@ function detached_run(code, ip::String="", port=detached_port();
         sigimagename = "",
         sigimageversion = "",
         imagename = "",
+        exename = "$(Sys.BINDIR)/julia",
         nretry = 10,
         verbose = 0,
         detachedservice = true)
@@ -503,6 +504,7 @@ function detached_run(code, ip::String="", port=detached_port();
             sigimagename = sigimagename,
             sigimageversion = sigimageversion,
             imagename = imagename,
+            exename = exename,
             nretry = nretry,
             verbose = verbose)
     else

--- a/src/detached_service.jl
+++ b/src/detached_service.jl
@@ -132,7 +132,7 @@ function detachedrun(request::HTTP.Request)
         julia_num_threads = nthreads_filter("$(Threads.nthreads()),$(Threads.nthreads(:interactive))")
         projectdir = dirname(Pkg.project().path)
         exename_parts = split(exename)
-        cmd = pipeline(Cmd(vcat(exename_parts, ["-t", julia_num_threads, "--project=$projectdir", _tempname_wrapper])))
+        cmd = pipeline(Cmd(String.(vcat(exename_parts, ["-t", julia_num_threads, "--project=$projectdir", _tempname_wrapper]))))
         process = open(cmd)
         pid = getpid(process)
         @info "executing $_tempname_wrapper with executable '$exename', $nthreads Julia threads, environment '$projectdir', and pid $pid"
@@ -140,9 +140,13 @@ function detachedrun(request::HTTP.Request)
         DETACHED_JOBS[string(id)] = Dict("process"=>process, "request"=>request, "stdout"=>outfile, "stderr"=>errfile, "codefile"=>_tempname, "code"=>code)
     catch e
         io = IOBuffer()
-        @error "caught error in detachedrun"
-        logerror(e, Logging.Debug)
-        return HTTP.Response(500, ["Content-Type"=>"application/json"], JSON.json(Dict("error"=>String(take!(io)))); request)
+        showerror(io, e, catch_backtrace())
+        errmsg = String(take!(io))
+        if isempty(errmsg)
+            errmsg = "$(typeof(e)): $(sprint(show, e))"
+        end
+        @error "caught error in detachedrun" exception=(e, catch_backtrace())
+        return HTTP.Response(500, ["Content-Type"=>"application/json"], JSON.json(Dict("error"=>errmsg)); request)
     end
 
     Threads.@spawn begin
@@ -151,8 +155,12 @@ function detachedrun(request::HTTP.Request)
         catch
         end
         if !r["persist"]
-            vm = AzManagers.DETACHED_VM[]
-            rmproc(vm; session=sessionbundle(:management))
+            try
+                vm = AzManagers.DETACHED_VM[]
+                rmproc(vm; session=AzSession(;protocal=AzClientCredentials))
+            catch e
+                @error "persist=false auto-delete failed" exception=(e, catch_backtrace())
+            end
         end
     end
     HTTP.Response(200, ["Content-Type"=>"application/json"], JSON.json(Dict("id"=>id, "pid"=>pid)); request)
@@ -208,7 +216,9 @@ function detachedstatus(request::HTTP.Request)
             status = "starting"
         end
     catch e
-        return HTTP.Response(500, ["Content-Type"=>"application/json"], JSON.json(Dict("error"=>show(e), "trace"=>show(stacktrace()))); request)
+        io = IOBuffer()
+        showerror(io, e, catch_backtrace())
+        return HTTP.Response(500, ["Content-Type"=>"application/json"], JSON.json(Dict("error"=>String(take!(io)))); request)
     end
     HTTP.Response(200, ["Content-Type"=>"application/json"], JSON.json(Dict("id"=>id, "status"=>status)); request)
 end

--- a/src/scaleset.jl
+++ b/src/scaleset.jl
@@ -14,8 +14,10 @@ function scaleset_pruning()
             =#
             prune_scalesets()
         catch e
-            @error "scaleset pruning error"
-            logerror(e, Logging.Debug)
+            if e isa InterruptException
+                break
+            end
+            @debug "scaleset pruning error" exception=(e, catch_backtrace())
         finally
             sleep(interval)
         end
@@ -31,9 +33,12 @@ function scaleset_cleaning()
             delete_pending_down_vms()
             delete_empty_scalesets()
             scaleset_sync()
+            prune_cluster()
         catch e
-            @error "scaleset cleaning error"
-            logerror(e, Logging.Debug)
+            if e isa InterruptException
+                break
+            end
+            @debug "scaleset cleaning error" exception=(e, catch_backtrace())
         end
     end
 end
@@ -80,9 +85,8 @@ function delete_pending_down_vms()
             scalesets(manager)[scaleset] = new_capacity
             delete!(pending_down(manager), scaleset)
         catch e
-            if status(e) == 404
-                @debug "scaleset $(scaleset.scalesetname) not found when attempting to delete vms, assuming it was already deleted."
-                # the resource is already deleted, nothing else to do except empty the pending down list for this scaleset
+            if status(e) in (404, 409)
+                @debug "scaleset $(scaleset.scalesetname) not found or already being deleted when attempting to delete vms, skipping."
                 if haskey(pending_down(manager), scaleset)
                     delete!(pending_down(manager), scaleset)
                 end
@@ -340,7 +344,21 @@ end
 #
 # Azure scale-set methods
 #
-function scaleset_image(manager::AzManager, sigimagename, sigimageversion, imagename)
+function _parse_image_ref(imageref_id::AbstractString)
+    parts = split(imageref_id, "/")
+    k_galleries = findfirst(x -> x == "galleries", parts)
+    k_images = findfirst(x -> x == "images", parts)
+    k_versions = findfirst(x -> x == "versions", parts)
+
+    gallery = k_galleries !== nothing ? parts[k_galleries+1] : ""
+    sigimagename = (k_galleries !== nothing && k_images !== nothing) ? parts[k_images+1] : ""
+    imagename = (k_galleries === nothing && k_images !== nothing) ? parts[k_images+1] : ""
+    sigimageversion = k_versions !== nothing ? parts[k_versions+1] : ""
+
+    sigimagename, sigimageversion, imagename
+end
+
+function scaleset_image(manager::AzManager, sigimagename, sigimageversion, imagename, template=nothing)
     # early exit
     if imagename != "" || (sigimagename != "" && sigimageversion != "")
         return sigimagename, sigimageversion, imagename
@@ -357,14 +375,28 @@ function scaleset_image(manager::AzManager, sigimagename, sigimageversion, image
     end
 
     istaskdone(t) || @async Base.throwto(t, InterruptException)
-    r = fetch(t)
+    r = try
+        fetch(t)
+    catch
+        nothing
+    end
 
     local _image
     if !isa(r, HTTP.Messages.Response)
+        # IMDS unavailable — fall back to template
+        if template !== nothing
+            return _scaleset_image_from_template(manager, sigimagename, sigimageversion, imagename, template)
+        end
         return sigimagename, sigimageversion, imagename
     else
-        r = fetch(t)
         image = JSON.parse(String(r.body))["id"]
+        if image == ""
+            # Marketplace image (no gallery id) — fall back to template
+            if template !== nothing
+                return _scaleset_image_from_template(manager, sigimagename, sigimageversion, imagename, template)
+            end
+            return sigimagename, sigimageversion, imagename
+        end
         _image = split(image,"/")
     end
 
@@ -412,6 +444,54 @@ function scaleset_image(manager::AzManager, sigimagename, sigimageversion, image
 
     @debug "after inspecting the VM metaddata, imagename=$imagename, sigimagename=$sigimagename, sigimageversion=$sigimageversion"
 
+    sigimagename, sigimageversion, imagename
+end
+
+function _scaleset_image_from_template(manager::AzManager, sigimagename, sigimageversion, imagename, template)
+    # Extract image reference from the template
+    local imageref_id
+    if haskey(template, "properties") && haskey(template["properties"], "virtualMachineProfile")
+        imageref_id = get(template["properties"]["virtualMachineProfile"]["storageProfile"]["imageReference"], "id", "")
+    elseif haskey(template, "properties") && haskey(template["properties"], "storageProfile")
+        imageref_id = get(template["properties"]["storageProfile"]["imageReference"], "id", "")
+    else
+        return sigimagename, sigimageversion, imagename
+    end
+
+    imageref_id == "" && return sigimagename, sigimageversion, imagename
+
+    t_sigimagename, t_sigimageversion, t_imagename = _parse_image_ref(imageref_id)
+
+    sigimagename == "" && (sigimagename = t_sigimagename)
+    imagename == "" && (imagename = t_imagename)
+
+    # If no version in template, query for the latest
+    if sigimagename != "" && sigimageversion == "" && t_sigimageversion == ""
+        parts = split(imageref_id, "/")
+        k_subscriptions = findfirst(x -> x == "subscriptions", parts)
+        k_resourcegroups = findfirst(x -> x == "resourceGroups", parts)
+        k_galleries = findfirst(x -> x == "galleries", parts)
+        if k_subscriptions !== nothing && k_resourcegroups !== nothing && k_galleries !== nothing
+            subscription = parts[k_subscriptions+1]
+            resourcegroup = parts[k_resourcegroups+1]
+            gallery = parts[k_galleries+1]
+            _r = @retry manager.nretry azrequest(
+                "GET",
+                manager.verbose,
+                "https://management.azure.com/subscriptions/$subscription/resourceGroups/$resourcegroup/providers/Microsoft.Compute/galleries/$gallery/images/$sigimagename/versions?api-version=2022-03-03",
+                ["Authorization"=>"Bearer $(token(manager.session))"])
+            r = JSON.parse(String(_r.body))
+            _versions, _r = getnextlinks!(manager, _r, get(r, "value", String[]), get(r, "nextLink", ""), manager.nretry, manager.verbose)
+            versions = VersionNumber.(get.(_versions, "name", ""))
+            if length(versions) > 0
+                sigimageversion = string(maximum(versions))
+            end
+        end
+    elseif t_sigimageversion != ""
+        sigimageversion = t_sigimageversion
+    end
+
+    @debug "from template: imagename=$imagename, sigimagename=$sigimagename, sigimageversion=$sigimageversion"
     sigimagename, sigimageversion, imagename
 end
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -171,22 +171,92 @@ spin(spincount, elapsed_time) = ['◐','◓','◑','◒','✓'][spincount]*@spri
 function software_sanity_check(manager, imagename, custom_environment)
     projectinfo = Pkg.project()
     envpath = normpath(joinpath(projectinfo.path, ".."))
-    _packages = TOML.parse(read(joinpath(envpath, "Manifest.toml"), String))
+    manifest_path = joinpath(envpath, "Manifest.toml")
 
+    if !isfile(manifest_path)
+        @debug "No Manifest.toml found at $manifest_path — skipping software sanity check"
+        return
+    end
+
+    _packages = TOML.parse(read(manifest_path, String))
     packages = _packages["deps"]
 
     if custom_environment
-        for (packagename, packageinfo) in packages
-            if haskey(packageinfo[1], "path")
-                error("Project/environment has dev'd packages that will not be accessible from workers.")
+        dev_packages = _detect_dev_packages(read(manifest_path, String), envpath)
+        if !isempty(dev_packages)
+            dev_names = join([name for (name, _, _) in dev_packages], ", ")
+            error("Project has Pkg.develop'd packages ($dev_names). " *
+                  "Workers cannot resolve local paths. Please Pkg.add these packages " *
+                  "and push all code changes before using customenv=true.")
+        end
+    end
+end
+
+"""
+    _detect_dev_packages(manifest_text, base_path) -> Vector{Tuple{String,String,String}}
+
+Detect Pkg.develop'd packages in a Manifest and return their git info as
+`(name, repo_url, repo_rev)` tuples. Packages without a discoverable git repo
+are logged as warnings and omitted.
+"""
+function _detect_dev_packages(manifest_text, base_path)
+    manifest = TOML.parse(manifest_text)
+    dev_pkgs = Tuple{String,String,String}[]
+
+    if !haskey(manifest, "deps")
+        return dev_pkgs
+    end
+
+    for (pkg_name, entries) in manifest["deps"]
+        for entry in entries
+            if haskey(entry, "path")
+                pkg_path = entry["path"]
+                pkg_path = isabspath(pkg_path) ? normpath(pkg_path) : normpath(joinpath(base_path, pkg_path))
+
+                try
+                    repo_url = readchomp(Cmd(["git", "-C", pkg_path, "remote", "get-url", "origin"]))
+                    repo_rev = readchomp(Cmd(["git", "-C", pkg_path, "rev-parse", "--abbrev-ref", "HEAD"]))
+                    if repo_rev == "HEAD"  # detached HEAD → use commit SHA
+                        repo_rev = readchomp(Cmd(["git", "-C", pkg_path, "rev-parse", "HEAD"]))
+                    end
+                    # Convert SSH URLs to HTTPS so workers can authenticate via .git-credentials
+                    m = match(r"^git@([^:]+):(.+)$", repo_url)
+                    if m !== nothing
+                        repo_url = "https://$(m.captures[1])/$(m.captures[2])"
+                    end
+                    push!(dev_pkgs, (pkg_name, repo_url, repo_rev))
+                    @debug "Dev'd package '$pkg_name' at $pkg_path → $repo_url#$repo_rev"
+                catch e
+                    @warn "Cannot determine git info for dev'd package '$pkg_name' at $pkg_path; " *
+                          "it will be removed from the worker environment" exception=e
+                end
             end
         end
     end
+
+    dev_pkgs
+end
+
+function sanitize_manifest(manifest_text)
+    manifest = TOML.parse(manifest_text)
+    if haskey(manifest, "deps")
+        for (pkg, entries) in manifest["deps"]
+            for entry in entries
+                delete!(entry, "path")
+            end
+        end
+    end
+    io = IOBuffer()
+    TOML.print(io, manifest)
+    String(take!(io))
 end
 
 function compress_environment(julia_environment_folder)
     project_text = read(joinpath(julia_environment_folder, "Project.toml"), String)
     manifest_text = read(joinpath(julia_environment_folder, "Manifest.toml"), String)
+
+    manifest_text = sanitize_manifest(manifest_text)
+
     localpreferences_text = isfile(joinpath(julia_environment_folder, "LocalPreferences.toml")) ? read(joinpath(julia_environment_folder, "LocalPreferences.toml"), String) : ""
     local project_compressed,manifest_compressed,localpreferences_compressed
     with_logger(ConsoleLogger(stdout, Logging.Info)) do

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -75,12 +75,16 @@ function preempted(instanceid::AbstractString, clusterid::Int)
         if time() - tic > 55 # 55 seconds, simply because it is less that 60, and 60 seconds is the eviction notice.
             @debug "$(now()), took longer than 55 seconds to query the meta-data server for scheduled events (elapsed time=$(time() - tic))."
         end
-    catch
-        @warn "unable to get scheduledevents."
+    catch e
+        @warn "unable to get scheduledevents" exception=(e, catch_backtrace())
         return false, ""
     end
     r = JSON.parse(String(_r.body))
-    for event in get(r, "Events", [])
+    events = get(r, "Events", [])
+    if !isempty(events)
+        @info "IMDS scheduledevents on pid=$clusterid: $(length(events)) event(s)" events
+    end
+    for event in events
         if get(event, "EventType", "") == "Preempt" && instanceid ∈ get(event, "Resources", [])
             @warn "Machine with id $clusterid ($instanceid) is being pre-empted" now(Dates.UTC) event["NotBefore"] event["EventType"] event["EventSource"]
             return true, event["NotBefore"]
@@ -90,7 +94,7 @@ function preempted(instanceid::AbstractString, clusterid::Int)
 end
 
 macro spawn_interactive(ex::Expr)
-    if VERSION > v"1.9"
+    if VERSION >= v"1.9"
         esc(:(Threads.@spawn :interactive $ex))
     else
         esc(:(Threads.@spawn $ex))
@@ -105,28 +109,33 @@ end
 Base.showerror(io::IO, e::SpotPreemptException) = print(io, "spot preemption on process '$(e.clusterid)' ($(e.instanceid)), not before '$(e.notbefore)'")
 
 function machine_preempt_loop(preempt_channel_future)
-    if VERSION >= v"1.9" && Threads.nthreads(:interactive) > 0
+    ninteractive = VERSION >= v"1.9" ? Threads.nthreads(:interactive) : 0
+    @info "machine_preempt_loop: pid=$(myid()), VERSION=$VERSION, interactive_threads=$ninteractive"
+    if VERSION >= v"1.9" && ninteractive > 0
         tsk = @spawn_interactive begin
             preempt_channel = fetch(preempt_channel_future)::Channel{Bool}
             instanceid = get_instanceid()
             clusterid = myid()
-            @debug "starting preempt loop on $clusterid, $instanceid"
+            @info "preempt loop started on pid=$clusterid, instanceid=$instanceid"
 
+            poll_count = 0
             while true
+                poll_count += 1
                 ispreempted, notbefore = preempted(instanceid, clusterid)
                 if ispreempted
-                    @debug "putting onto preempt_channel"
+                    @info "preempt detected on pid=$clusterid after $poll_count polls"
                     put!(preempt_channel, true)
-                    @debug "done putting onto preempt_channel"
-                    # pid=1 will catch this exception, and remove the worker from the Julia cluster.
                     throw(SpotPreemptException(instanceid, clusterid, notbefore))
+                end
+                if poll_count % 30 == 0
+                    @info "preempt loop heartbeat: pid=$clusterid, polls=$poll_count, no preempt detected"
                 end
                 sleep(1)
             end
         end
         fetch(tsk)
     else
-        @warn "AzManagers is not running the preempt loop for pid=$(myid()) since it requires at least one interactive thread on worker machines."
+        @warn "preempt loop NOT running on pid=$(myid()): requires Julia ≥ 1.9 with interactive threads" VERSION ninteractive
     end
 end
 
@@ -191,8 +200,18 @@ function azure_worker_init(cookie, master_address, master_port, ppi, exeflags, m
     nbytes_written == Distributed.HDR_COOKIE_LEN || error("unable to write bytes")
     flush(c)
 
-    _r = HTTP.request("GET", "http://169.254.169.254/metadata/instance?api-version=2021-02-01", ["Metadata"=>"true"]; redirect=false)
-    r = JSON.parse(String(_r.body))
+    local r
+    for attempt in 1:3
+        try
+            _r = HTTP.request("GET", "http://169.254.169.254/metadata/instance?api-version=2021-02-01", ["Metadata"=>"true"]; redirect=false, readtimeout=30)
+            r = JSON.parse(String(_r.body))
+            break
+        catch e
+            @warn "IMDS metadata request failed (attempt $attempt/3)" exception=(e, catch_backtrace())
+            attempt == 3 && rethrow()
+            sleep(5 * attempt)
+        end
+    end
     vm = Dict(
         "exeflags" => exeflags,
         "bind_addr" => string(getipaddr(IPv4)),
@@ -287,8 +306,12 @@ function azure_worker_start(out::IO, cookie::AbstractString=readline(stdin); clo
     print(out, '\n')
     flush(out)
 
-    Sockets.nagle(sock, false)
-    Sockets.quickack(sock, true)
+    try
+        Sockets.nagle(sock, false)
+        Sockets.quickack(sock, true)
+    catch e
+        @debug "failed to set socket options" exception=(e, catch_backtrace())
+    end
 
     if ccall(:jl_running_on_valgrind,Cint,()) != 0
         println(out, "PID = $(getpid())")
@@ -781,12 +804,19 @@ function simulate_spot_eviction(pid)
     resourcegroup = Distributed.map_pid_wrkr[pid].config.userdata["resourcegroup"]
     scalesetname = Distributed.map_pid_wrkr[pid].config.userdata["scalesetname"]
 
+    @info "simulate_spot_eviction: pid=$pid, instanceid=$instanceid, scaleset=$scalesetname"
+
     manager = azmanager()
     session = manager.session
 
-    HTTP.request(
+    r = HTTP.request(
         "POST",
         "https://management.azure.com/subscriptions/$subscriptionid/resourceGroups/$resourcegroup/providers/Microsoft.Compute/virtualMachineScaleSets/$scalesetname/virtualMachines/$instanceid/simulateEviction?api-version=2023-03-01",
-        ["Authorization" => "Bearer $(token(session))"])
+        ["Authorization" => "Bearer $(token(session))"];
+        status_exception=false)
+    @info "simulate_spot_eviction response" status=r.status body=String(r.body)
+    if r.status >= 300
+        @warn "simulate_spot_eviction failed" status=r.status body=String(r.body)
+    end
     nothing
 end


### PR DESCRIPTION
## Summary

Source-only changes extracted from the larger unit_test_refactor branch. No test or CI changes.

### Changes

1. **Dev package detection** — `_detect_dev_packages()` discovers git remote+branch for Pkg.develop'd packages
2. **Dev package guard** — `software_sanity_check()` now errors on dev'd packages with `customenv=true` (workers can't resolve local paths)
3. **Bug fixes:**
   - `detached_service.jl`: Fix persist=false auto-delete (use AzSession directly)
   - `scaleset.jl`: Add `prune_cluster()` to `scaleset_cleaning()` so dead workers are detected
   - `scaleset.jl`: Add InterruptException handling to break background loops cleanly
   - `scaleset.jl`: Demote transient Azure API errors from @error to @debug
4. **Manifest.toml guard** — `software_sanity_check()` skips gracefully when Manifest.toml is absent (Pkg.test() environments)
5. **Spot eviction telemetry:**
   - Promote preempt loop logging to @info with poll counters and heartbeat
   - IMDS metadata retry (3 attempts with backoff, readtimeout=30)
   - Socket option setting wrapped in try/catch
   - Spinner timeout to prevent infinite hangs
   - Server-socket-closed detection in connection listener
6. **Include order fix** — types.jl must precede utilities.jl (utilities.jl references AzManager type)

### Testing

- Module loads cleanly
- Unit tests pass (84/84)