### PR TITLE
Pre-validate connections before batching

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AzManagers"
 uuid = "db05ebb0-6096-11e9-199b-87b703361841"
 authors = ["samtkaplan <sam.kaplan@chevron.com>"]
-version = "3.17.8"
+version = "3.17.9"
 
 [deps]
 AzSessions = "f239b30d-ae6b-58be-a2d5-7e9f30e280a9"

--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -520,13 +520,57 @@ function add_pending_connections()
     end
 end
 
-function Distributed.addprocs(manager::AzManager; sockets)
+function validate_connection(manager, socket)
+    validation_timeout = parse(Float64, get(ENV, "JULIA_AZMANAGERS_VALIDATION_TIMEOUT", "30.0"))
+    tsk = @async _read_worker_config(socket)
+
+    watchdog = Timer(validation_timeout) do _
+        if !istaskdone(tsk)
+            @async Base.throwto(tsk, InterruptException())
+        end
+    end
+
+    local wconfig
+    try
+        wconfig = fetch(tsk)
+    catch e
+        @warn "connection validation failed, discarding socket" exception=(e, catch_backtrace())
+        close(socket)
+        return nothing
+    finally
+        close(watchdog)
+    end
+
+    wconfig
+end
+
+function _read_worker_config(socket)
+    _cookie = read(socket, Distributed.HDR_COOKIE_LEN)
+    cookie = String(_cookie)
+    cookie == Distributed.cluster_cookie() || error("Invalid cookie sent by remote worker.")
+
+    _connection_string = readline(socket)
+    connection_string = String(base64decode(_connection_string))
+    vm = JSON.parse(connection_string)
+
+    wconfig = WorkerConfig()
+    wconfig.io = socket
+    wconfig.bind_addr = vm["bind_addr"]
+    wconfig.count = vm["ppi"]
+    wconfig.exename = "julia"
+    wconfig.exeflags = `$(vm["exeflags"])`
+    wconfig.userdata = vm["userdata"]
+
+    wconfig
+end
+
+function Distributed.addprocs(manager::AzManager; wconfigs)
     pids = []
     try
         Distributed.init_multi()
         Distributed.cluster_mgmt_from_master_check()
         lock(Distributed.worker_lock)
-        pids = Distributed.addprocs_locked(manager; sockets)
+        pids = Distributed.addprocs_locked(manager; wconfigs)
     catch e
         @debug "AzManagers, error processing pending connection"
         logerror(e, Logging.Debug)
@@ -536,11 +580,11 @@ function Distributed.addprocs(manager::AzManager; sockets)
     pids
 end
 
-function addprocs_with_timeout(manager; sockets)
+function addprocs_with_timeout(manager; wconfigs)
     # Distributed.setup_launched_worker also uses Distributed.worker_timeout, so we add a grace period
     # to allow for the Distributed.setup_launched_worker to hit its timeout.
     timeout = Distributed.worker_timeout() + 30
-    tsk_addprocs = @async addprocs(manager; sockets)
+    tsk_addprocs = @async addprocs(manager; wconfigs)
     tic = time()
     pids = []
     interrupted = false
@@ -571,32 +615,42 @@ end
 
 function process_pending_connections()
     manager = azmanager()
-    sockets = TCPSocket[]
+    wconfigs = WorkerConfig[]
 
-    max_sockets = manager.pending_up.sz_max
+    max_wconfigs = manager.pending_up.sz_max
     min_instances_per_second = parse(Float64, get(ENV, "JULIA_AZMANAGERS_MIN_INSTANCES_PER_MINUTE", "10")) / 60 # if we drop below N new instances per minute, then we trigger addprocs
     min_cadence = parse(Int, get(ENV, "JULIA_AZMANAGERS_PENDING_CADENCE", "60"))
     tic = time()
     while true
         try
-            if isempty(sockets)
+            local socket
+            if isempty(wconfigs)
                 @debug "taking from manager.pending_up" manager.pending_up.n_avail_items
-                push!(sockets, take!(manager.pending_up))
-                @debug "done taking from manager.pending_up" manager.pending_up.n_avail_items length(sockets)
-            elseif isready(manager.pending_up) && length(sockets) < max_sockets
+                socket = take!(manager.pending_up)
+                @debug "done taking from manager.pending_up" manager.pending_up.n_avail_items
+            elseif isready(manager.pending_up) && length(wconfigs) < max_wconfigs
                 @debug "taking from manager.pending_up" manager.pending_up.n_avail_items
-                push!(sockets, take!(manager.pending_up))
-                @debug "done taking from manager.pending_up" manager.pending_up.n_avail_items length(sockets)
+                socket = take!(manager.pending_up)
+                @debug "done taking from manager.pending_up" manager.pending_up.n_avail_items
             else
                 sleep(0.1)
+                socket = nothing
+            end
+
+            if socket !== nothing
+                wconfig = validate_connection(manager, socket)
+                if wconfig !== nothing
+                    push!(wconfigs, wconfig)
+                    @debug "validated connection added to batch" length(wconfigs)
+                end
             end
 
             elapsedtime = time() - tic
-            instances_per_second = length(sockets)/elapsedtime
-            if length(sockets) == 0 || (elapsedtime < min_cadence && instances_per_second > min_instances_per_second && length(sockets) < max_sockets)
+            instances_per_second = length(wconfigs)/elapsedtime
+            if length(wconfigs) == 0 || (elapsedtime < min_cadence && instances_per_second > min_instances_per_second && length(wconfigs) < max_wconfigs)
                 continue
             else
-                @debug "triggered adding machines" elapsedtime min_cadence instances_per_second min_instances_per_second length(sockets) max_sockets nworkers_provisioned()
+                @debug "triggered adding machines" elapsedtime min_cadence instances_per_second min_instances_per_second length(wconfigs) max_wconfigs nworkers_provisioned()
             end
         catch e
             @error "AzManagers, error retrieving pending connection"
@@ -605,9 +659,9 @@ function process_pending_connections()
         end
 
         @debug "calling addprocs_with_timeout from process_pending_connections"
-        pids = addprocs_with_timeout(manager; sockets)
+        pids = addprocs_with_timeout(manager; wconfigs)
         @debug "done calling addprocs_with_timeout from process_pending_connections"
-        empty!(sockets)
+        empty!(wconfigs)
         tic = time()
 
         @debug "starting preempt loops" pids
@@ -887,59 +941,12 @@ function Distributed.addprocs(template::AbstractString, n::Int; kwargs...)
 end
 
 function Distributed.launch(manager::AzManager, params::Dict, launched::Array, c::Condition)
-    sockets = params[:sockets]
+    wconfigs = params[:wconfigs]
 
-    @sync for socket in sockets
-        @async try
-            Distributed.launch_on_machine(manager, launched, c, socket)
-        catch e
-            @error "failed to launch on machine for socket=$socket"
-            logerror(e, Logging.Debug)
-        end
+    for wconfig in wconfigs
+        push!(launched, wconfig)
+        notify(c)
     end
-    notify(c)
-end
-
-function Distributed.launch_on_machine(manager::AzManager, launched, c, socket)
-    local _cookie
-    try
-        _cookie = read(socket, Distributed.HDR_COOKIE_LEN)
-    catch e
-        @error "unable to read cookie from socket"
-        logerror(e, Logging.Debug)
-        return
-    end
-
-    cookie = String(_cookie)
-    cookie == Distributed.cluster_cookie() || error("Invalid cookie sent by remote worker.")
-
-    local _connection_string
-    try
-        _connection_string = readline(socket)
-    catch e
-        @error "unable to read connection string from socket"
-        throw(e)
-    end
-
-    connection_string = String(base64decode(_connection_string))
-
-    local vm
-    try
-        vm = JSON.parse(connection_string)
-    catch e
-        @error "unable to parse connection string, string=$connection_string, cookie=$cookie"
-        throw(e)
-    end
-
-    wconfig = WorkerConfig()
-    wconfig.io = socket
-    wconfig.bind_addr = vm["bind_addr"]
-    wconfig.count = vm["ppi"]
-    wconfig.exename = "julia"
-    wconfig.exeflags = `$(vm["exeflags"])`
-    wconfig.userdata = vm["userdata"]
-
-    push!(launched, wconfig)
     notify(c)
 end
 

--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -188,6 +188,7 @@ mutable struct AzManager <: ClusterManager
     show_quota::Bool
     scalesets::Dict{ScaleSet,Int}
     pending_up::Channel{TCPSocket}
+    pending_validated::Channel{WorkerConfig}
     pending_down::Dict{ScaleSet,Set{String}}
     deleted::Dict{ScaleSet,Dict{String,DateTime}}
     pruned::Dict{ScaleSet,Set{String}}
@@ -221,6 +222,7 @@ function azmanager!(session, ssh_user, nretry, verbose, save_cloud_init_failures
 
     _manager.port,_manager.server = listenany(getipaddr(), 9000)
     _manager.pending_up = Channel{TCPSocket}(64)
+    _manager.pending_validated = Channel{WorkerConfig}(64)
     _manager.pending_down = Dict{ScaleSet,Set{String}}()
     _manager.deleted = Dict{ScaleSet,Dict{String,DateTime}}()
     _manager.pruned = Dict{ScaleSet,Set{String}}()
@@ -509,9 +511,17 @@ function add_pending_connections()
     while true
         try
             let s = accept(manager.server)
-                @debug "pushing new socket onto manger.pending_up" manager.pending_up.n_avail_items
-                put!(manager.pending_up, s)
-                @debug "done pushing new socket onto manger.pending_up" manager.pending_up.n_avail_items
+                @debug "accepted new socket, spawning validation"
+                @async try
+                    wconfig = validate_connection(manager, s)
+                    if wconfig !== nothing
+                        put!(manager.pending_validated, wconfig)
+                        @debug "validated connection queued" manager.pending_validated.n_avail_items
+                    end
+                catch e
+                    @error "AzManagers, error validating connection"
+                    logerror(e, Logging.Debug)
+                end
             end
         catch e
             @error "AzManagers, error adding pending connection"
@@ -617,32 +627,22 @@ function process_pending_connections()
     manager = azmanager()
     wconfigs = WorkerConfig[]
 
-    max_wconfigs = manager.pending_up.sz_max
+    max_wconfigs = manager.pending_validated.sz_max
     min_instances_per_second = parse(Float64, get(ENV, "JULIA_AZMANAGERS_MIN_INSTANCES_PER_MINUTE", "10")) / 60 # if we drop below N new instances per minute, then we trigger addprocs
     min_cadence = parse(Int, get(ENV, "JULIA_AZMANAGERS_PENDING_CADENCE", "60"))
     tic = time()
     while true
         try
-            local socket
             if isempty(wconfigs)
-                @debug "taking from manager.pending_up" manager.pending_up.n_avail_items
-                socket = take!(manager.pending_up)
-                @debug "done taking from manager.pending_up" manager.pending_up.n_avail_items
-            elseif isready(manager.pending_up) && length(wconfigs) < max_wconfigs
-                @debug "taking from manager.pending_up" manager.pending_up.n_avail_items
-                socket = take!(manager.pending_up)
-                @debug "done taking from manager.pending_up" manager.pending_up.n_avail_items
+                @debug "taking from manager.pending_validated" manager.pending_validated.n_avail_items
+                push!(wconfigs, take!(manager.pending_validated))
+                @debug "done taking from manager.pending_validated" manager.pending_validated.n_avail_items length(wconfigs)
+            elseif isready(manager.pending_validated) && length(wconfigs) < max_wconfigs
+                @debug "taking from manager.pending_validated" manager.pending_validated.n_avail_items
+                push!(wconfigs, take!(manager.pending_validated))
+                @debug "done taking from manager.pending_validated" manager.pending_validated.n_avail_items length(wconfigs)
             else
                 sleep(0.1)
-                socket = nothing
-            end
-
-            if socket !== nothing
-                wconfig = validate_connection(manager, socket)
-                if wconfig !== nothing
-                    push!(wconfigs, wconfig)
-                    @debug "validated connection added to batch" length(wconfigs)
-                end
             end
 
             elapsedtime = time() - tic

--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -544,7 +544,7 @@ function validate_connection(manager, socket)
     try
         wconfig = fetch(tsk)
     catch e
-        @warn "connection validation failed, discarding socket" exception=(e, catch_backtrace())
+        @debug "connection validation failed, discarding socket" exception=(e, catch_backtrace())
         close(socket)
         return nothing
     finally

--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -222,7 +222,7 @@ function azmanager!(session, ssh_user, nretry, verbose, save_cloud_init_failures
 
     _manager.port,_manager.server = listenany(getipaddr(), 9000)
     _manager.pending_up = Channel{TCPSocket}(64)
-    _manager.pending_validated = Channel{WorkerConfig}(64)
+    _manager.pending_validated = Channel{WorkerConfig}(parse(Int, get(ENV, "JULIA_AZMANAGERS_VALIDATED_CHANNEL_SIZE", "512")))
     _manager.pending_down = Dict{ScaleSet,Set{String}}()
     _manager.deleted = Dict{ScaleSet,Dict{String,DateTime}}()
     _manager.pruned = Dict{ScaleSet,Set{String}}()
@@ -636,9 +636,10 @@ function process_pending_connections()
     manager = azmanager()
     wconfigs = WorkerConfig[]
 
-    max_wconfigs = manager.pending_validated.sz_max
+    max_wconfigs = parse(Int, get(ENV, "JULIA_AZMANAGERS_MAX_BATCH_SIZE", "64"))
     min_instances_per_second = parse(Float64, get(ENV, "JULIA_AZMANAGERS_MIN_INSTANCES_PER_MINUTE", "10")) / 60 # if we drop below N new instances per minute, then we trigger addprocs
-    min_cadence = parse(Int, get(ENV, "JULIA_AZMANAGERS_PENDING_CADENCE", "60"))
+    min_cadence = parse(Int, get(ENV, "JULIA_AZMANAGERS_PENDING_CADENCE", "5"))
+    tsk_addprocs = nothing  # track in-flight addprocs task
     tic = time()
     while true
         try
@@ -667,57 +668,67 @@ function process_pending_connections()
             continue
         end
 
+        # Wait for any in-flight addprocs to finish before starting a new batch
+        # (Distributed.worker_lock prevents concurrent addprocs_locked calls)
+        if tsk_addprocs !== nothing && !istaskdone(tsk_addprocs)
+            @debug "waiting for previous addprocs batch to complete"
+            wait(tsk_addprocs)
+        end
+
         @debug "calling addprocs_with_timeout from process_pending_connections"
         batch_size = length(wconfigs)
-        pids = addprocs_with_timeout(manager; wconfigs)
-        @info "batch complete" submitted=batch_size registered=length(pids) dropped=batch_size-length(pids)
+        local batch_wconfigs = copy(wconfigs)
         empty!(wconfigs)
         tic = time()
+        tsk_addprocs = @async begin
+            pids = addprocs_with_timeout(manager; wconfigs=batch_wconfigs)
+            @info "batch complete" submitted=batch_size registered=length(pids) dropped=batch_size-length(pids)
 
-        @debug "starting preempt loops" pids
-        for pid in pids
-            @async begin
-                wrkr = Distributed.map_pid_wrkr[pid]
-                if isdefined(wrkr, :config) && isdefined(wrkr.config, :userdata) && lowercase(get(wrkr.config.userdata, "priority", "")) == "spot"
-                    try
-                        manager.preempt_channel_futures[pid] = remotecall(Channel{Bool}, pid, 1)
-                        remotecall_fetch(machine_preempt_loop, pid, manager.preempt_channel_futures[pid])
-                    catch e
-                        if isa(e, RemoteException) && isa(e.captured.ex, TaskFailedException) && isa(e.captured.ex.task.result.ex, SpotPreemptException)
-                            ex = e.captured.ex.task.result.ex
-                            notbefore = DateTime(ex.notbefore, dateformat"e, dd u yyyy HH:MM:SS \G\M\T")
-                            @info "caught preempt exception for $(ex.clusterid), removing not before $notbefore UTC"
-                            _now = now(UTC)
-                            if notbefore > _now
-                                @debug "sleeping for preempt grace period" duration=notbefore - _now
-                                sleep(notbefore - _now)
-                            end
-                            u = wrkr.config.userdata
-                            try
-                                scaleset = ScaleSet(u["subscriptionid"], u["resourcegroup"], u["scalesetname"])
-                                add_instance_to_preempted_list(manager, scaleset, u["instanceid"])
-                            catch e
-                                @error "error adding instance to preempted list" instanceid=get(u, "instanceid", "unknown")
-                            end
-
-                            try
-                                lock(Distributed.worker_lock)
-                                if haskey(Distributed.map_pid_wrkr, pid)
-                                    # We can't use rmprocs here since the worker process might already be gone due to preemption.  The
-                                    # worker process would usually do the following two lines (see the Distributed.message_handler_loop function)
-                                    Distributed.set_worker_state(Distributed.map_pid_wrkr[pid], Distributed.W_TERMINATED)
-                                    Distributed.deregister_worker(pid)
+            @debug "starting preempt loops" pids
+            for pid in pids
+                @async begin
+                    wrkr = Distributed.map_pid_wrkr[pid]
+                    if isdefined(wrkr, :config) && isdefined(wrkr.config, :userdata) && lowercase(get(wrkr.config.userdata, "priority", "")) == "spot"
+                        try
+                            manager.preempt_channel_futures[pid] = remotecall(Channel{Bool}, pid, 1)
+                            remotecall_fetch(machine_preempt_loop, pid, manager.preempt_channel_futures[pid])
+                        catch e
+                            if isa(e, RemoteException) && isa(e.captured.ex, TaskFailedException) && isa(e.captured.ex.task.result.ex, SpotPreemptException)
+                                ex = e.captured.ex.task.result.ex
+                                notbefore = DateTime(ex.notbefore, dateformat"e, dd u yyyy HH:MM:SS \G\M\T")
+                                @info "caught preempt exception for $(ex.clusterid), removing not before $notbefore UTC"
+                                _now = now(UTC)
+                                if notbefore > _now
+                                    @debug "sleeping for preempt grace period" duration=notbefore - _now
+                                    sleep(notbefore - _now)
                                 end
-                            catch
-                            finally
-                                unlock(Distributed.worker_lock)
+                                u = wrkr.config.userdata
+                                try
+                                    scaleset = ScaleSet(u["subscriptionid"], u["resourcegroup"], u["scalesetname"])
+                                    add_instance_to_preempted_list(manager, scaleset, u["instanceid"])
+                                catch e
+                                    @error "error adding instance to preempted list" instanceid=get(u, "instanceid", "unknown")
+                                end
+
+                                try
+                                    lock(Distributed.worker_lock)
+                                    if haskey(Distributed.map_pid_wrkr, pid)
+                                        # We can't use rmprocs here since the worker process might already be gone due to preemption.  The
+                                        # worker process would usually do the following two lines (see the Distributed.message_handler_loop function)
+                                        Distributed.set_worker_state(Distributed.map_pid_wrkr[pid], Distributed.W_TERMINATED)
+                                        Distributed.deregister_worker(pid)
+                                    end
+                                catch
+                                finally
+                                    unlock(Distributed.worker_lock)
+                                end
                             end
                         end
                     end
                 end
             end
+            @debug "done starting preempt loops"
         end
-        @debug "done starting preempt loops"
     end
 end
 

--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -293,11 +293,11 @@ scalesets() = scalesets(azmanager())
 pending_down(manager::AzManager) = isdefined(manager, :pending_down) ? manager.pending_down : Dict{ScaleSet,Set{String}}()
 
 function delete_scaleset(manager, scaleset)
-    @debug "deleting scaleset, $scaleset"
+    @info "deleting scaleset" scalesetname=scaleset.scalesetname resourcegroup=scaleset.resourcegroup
     try
         rmgroup(manager, scaleset.subscriptionid, scaleset.resourcegroup, scaleset.scalesetname, manager.nretry, manager.verbose, manager.show_quota)
     catch e
-        @warn "unable to remove scaleset $(scaleset.resourcegroup), $(scaleset.scalesetname)"
+        @warn "unable to remove scaleset" scalesetname=scaleset.scalesetname resourcegroup=scaleset.resourcegroup
     end
     delete!(scalesets(manager), scaleset)
 end
@@ -323,11 +323,13 @@ function delete_pending_down_vms()
     lock(manager.lock)
 
     for (scaleset, ids) in pending_down(manager)
-        @debug "deleting pending down vms $ids in $scaleset"
+        old_capacity = get(scalesets(manager), scaleset, 0)
+        @info "deleting pending_down vms" scalesetname=scaleset.scalesetname count=length(ids) ids=ids current_capacity=old_capacity
         try
             delete_vms(manager, scaleset.subscriptionid, scaleset.resourcegroup, scaleset.scalesetname, ids, manager.nretry, manager.verbose)
             new_capacity = max(0, scalesets(manager)[scaleset] - length(ids))
             scalesets(manager)[scaleset] = new_capacity
+            @info "deleted pending_down vms" scalesetname=scaleset.scalesetname old_capacity=old_capacity new_capacity=new_capacity
             delete!(pending_down(manager), scaleset)
         catch e
             if status(e) == 404
@@ -353,11 +355,14 @@ function scaleset_sync()
     try
         _pending_down = pending_down(manager)
         pending_down_count = isempty(_pending_down) ? 0 : mapreduce(length, +, values(_pending_down))
-        if nprocs()-1+pending_down_count != nworkers_provisioned()
-            @debug "client/server scaleset book-keeping mismatch, synching client to server."
+        _nworkers_provisioned = nworkers_provisioned()
+        if nprocs()-1+pending_down_count != _nworkers_provisioned
+            @info "scaleset sync: client/server mismatch" cluster_workers=nprocs()-1 pending_down=pending_down_count provisioned=_nworkers_provisioned
             _scalesets = scalesets(manager)
             for scaleset in keys(_scalesets)
+                old_capacity = _scalesets[scaleset]
                 _scalesets[scaleset] = scaleset_capacity(manager, scaleset.subscriptionid, scaleset.resourcegroup, scaleset.scalesetname, manager.nretry, manager.verbose)
+                @info "scaleset sync: updated capacity" scalesetname=scaleset.scalesetname old=old_capacity new=_scalesets[scaleset]
             end
         end
     catch e
@@ -481,9 +486,11 @@ function prune_scalesets()
 
             doprune = (time_elapsed > worker_timeout || vm_state == "failed") && !is_worker_deleting && !is_vm_deleting && !ispruned_already
             if doprune
-                @info "Putting machine with instance id $instanceid in $(scaleset.scalesetname) onto the deletion queue because it failed to join the Julia cluster after $(round(time_elapsed, Second)), vm_state=$vm_state."
+                vm_name = get(_vm, "name", "unknown")
+                power_state = lowercase(get(get(get(_vm, "properties", Dict()), "instanceView", Dict()), "powerState", get(get(_vm, "properties", Dict()), "provisioningState", "unknown")))
+                @warn "worker failed to join cluster" instanceid=instanceid vm_name=vm_name scalesetname=scaleset.scalesetname elapsed=round(time_elapsed, Second) vm_state=vm_state power_state=power_state timeout=worker_timeout
                 if manager.save_cloud_init_failures
-                    @info "copying cloud init output log to '$(pwd())/cloud-init-output-$(instanceid).log'."
+                    @debug "copying cloud init output log to '$(pwd())/cloud-init-output-$(instanceid).log'."
                     try
                         ipaddress = get_ipaddress_for_scaleset_vm(manager, _vm)
                         run(`scp -i $(homedir())/.ssh/azmanagers_rsa $(manager.ssh_user)@$(ipaddress):/var/log/cloud-init-output.log ./cloud-init-output-$(instanceid).log`)
@@ -519,7 +526,8 @@ function add_pending_connections()
                         @debug "validated connection queued" manager.pending_validated.n_avail_items
                     end
                 catch e
-                    @error "AzManagers, error validating connection"
+                    peer = try string(getpeername(s)) catch; "unknown" end
+                    @warn "connection validation error" peer=peer
                     logerror(e, Logging.Debug)
                 end
             end
@@ -544,7 +552,8 @@ function validate_connection(manager, socket)
     try
         wconfig = fetch(tsk)
     catch e
-        @debug "connection validation failed, discarding socket" exception=(e, catch_backtrace())
+        peer = try string(getpeername(socket)) catch; "unknown" end
+        @warn "connection validation failed, discarding socket" peer=peer timeout=validation_timeout exception=(e, catch_backtrace())
         close(socket)
         return nothing
     finally
@@ -650,7 +659,7 @@ function process_pending_connections()
             if length(wconfigs) == 0 || (elapsedtime < min_cadence && instances_per_second > min_instances_per_second && length(wconfigs) < max_wconfigs)
                 continue
             else
-                @debug "triggered adding machines" elapsedtime min_cadence instances_per_second min_instances_per_second length(wconfigs) max_wconfigs nworkers_provisioned()
+                @info "batch ready: adding workers" batch_size=length(wconfigs) elapsed=round(elapsedtime, digits=1) rate=round(instances_per_second, digits=3) provisioned=nworkers_provisioned()
             end
         catch e
             @error "AzManagers, error retrieving pending connection"
@@ -659,8 +668,9 @@ function process_pending_connections()
         end
 
         @debug "calling addprocs_with_timeout from process_pending_connections"
+        batch_size = length(wconfigs)
         pids = addprocs_with_timeout(manager; wconfigs)
-        @debug "done calling addprocs_with_timeout from process_pending_connections"
+        @info "batch complete" submitted=batch_size registered=length(pids) dropped=batch_size-length(pids)
         empty!(wconfigs)
         tic = time()
 
@@ -679,7 +689,7 @@ function process_pending_connections()
                             @info "caught preempt exception for $(ex.clusterid), removing not before $notbefore UTC"
                             _now = now(UTC)
                             if notbefore > _now
-                                @info "sleeping for $(notbefore - _now)"
+                                @debug "sleeping for preempt grace period" duration=notbefore - _now
                                 sleep(notbefore - _now)
                             end
                             u = wrkr.config.userdata
@@ -687,7 +697,7 @@ function process_pending_connections()
                                 scaleset = ScaleSet(u["subscriptionid"], u["resourcegroup"], u["scalesetname"])
                                 add_instance_to_preempted_list(manager, scaleset, u["instanceid"])
                             catch e
-                                @info "error adding instance to preempted list"
+                                @error "error adding instance to preempted list" instanceid=get(u, "instanceid", "unknown")
                             end
 
                             try
@@ -732,9 +742,11 @@ function Distributed.setup_launched_worker(manager::AzManager, wconfig, launched
             sleep(1)
         end
     catch e
-        @warn "unable to create worker within $timeout seconds, adding vm to pending down list"
-        logerror(e, Logging.Debug)
         u = wconfig.userdata
+        instanceid = get(u, "instanceid", "unknown")
+        vm_name = get(u, "name", "unknown")
+        @warn "worker failed to register" instanceid=instanceid vm_name=vm_name scalesetname=get(u, "scalesetname", "unknown") timeout=timeout
+        logerror(e, Logging.Debug)
         scaleset = ScaleSet(u["subscriptionid"], u["resourcegroup"], u["scalesetname"])
         add_instance_to_pending_down_list(manager, scaleset, u["instanceid"])
         add_instance_to_deleted_list(manager, scaleset, u["instanceid"])
@@ -952,10 +964,10 @@ end
 
 function add_instance_to_pending_down_list(manager::AzManager, scaleset::ScaleSet, instanceid)
     if haskey(manager.pending_down, scaleset)
-        @debug "pushing worker with id=$instanceid onto pending_down"
+        @info "adding instance to pending_down" instanceid=instanceid scalesetname=scaleset.scalesetname pending_down_size=length(manager.pending_down[scaleset])+1
         push!(manager.pending_down[scaleset], string(instanceid))
     else
-        @debug "creating pending_down vector for id=$instanceid"
+        @info "adding instance to pending_down (new set)" instanceid=instanceid scalesetname=scaleset.scalesetname
         manager.pending_down[scaleset] = Set{String}([string(instanceid)])
     end
     nothing
@@ -1000,7 +1012,10 @@ function add_instance_to_deleted_list(manager::AzManager, scaleset::ScaleSet, in
 end
 
 function Distributed.kill(manager::AzManager, id::Int, config::WorkerConfig)
-    @debug "kill for id=$id"
+    u = config.userdata
+    instanceid = get(u, "instanceid", "unknown")
+    vm_name = get(u, "name", "unknown")
+    @info "killing worker" pid=id instanceid=instanceid vm_name=vm_name scalesetname=get(u, "scalesetname", "unknown")
 
     if ispreempted(manager, config)
         @debug "kill on id=$id because it was preempted"
@@ -1432,7 +1447,7 @@ function azure_worker_start(out::IO, cookie::AbstractString=readline(stdin); clo
     try
         while true
             Distributed.check_master_connect()
-            @info "message loop..."
+            @debug "message loop..."
             wait(t)
             istaskfailed(t) && fetch(t)
             sleep(10)
@@ -1765,7 +1780,7 @@ function nvidia_gpumode(feature)
     else
         @warn "unable to retrieve status for feature='$feature'"
     end
-    @info "NVIDIA $feature is $isenabled"
+    @debug "NVIDIA $feature is $isenabled"
     isenabled
 end
 
@@ -1774,12 +1789,12 @@ function nvidia_gpumode!(feature, switch)
     p = open(`sudo nvidia-smi $feature $_switch`)
     wait(p)
     success(p) || @error "unable to toggle NVIDIA GPU feature='$feature' to '$_switch'."
-    @info "NVIDIA $feature is toggled to $_switch"
+    @debug "NVIDIA $feature is toggled to $_switch"
 end
 
 function nvidia_gpucheck(enable_ecc=true, enable_mig=false)
     if !nvidia_has_nvidia_smi()
-        @info "no NVIDIA devices detected."
+        @debug "no NVIDIA devices detected."
         return
     end
 
@@ -1801,7 +1816,7 @@ end
 
 function build_lvm()
     if isfile("/usr/sbin/azure_nvme.sh")
-        @info "Building scratch.."
+        @debug "Building scratch.."
         run(`sudo bash /usr/sbin/azure_nvme.sh`)
     else 
         @warn "No scratch nvme script found!"
@@ -2499,6 +2514,8 @@ function scaleset_create_or_update(manager::AzManager, user, subscriptionid, res
 
     @debug "done checking quota, δn=$(δn), n=$n"
 
+    @info "scaling scaleset" scalesetname=scalesetname target_capacity=n added=δn spot=spot
+
     _template["sku"]["capacity"] = n
     _r = @retry nretry azrequest(
         "PUT",
@@ -2531,7 +2548,7 @@ end
 # see https://docs.microsoft.com/en-us/azure/virtual-machines/linux/add-disk
 function mount_datadisks()
     try
-        @info "mounting data disks"
+        @debug "mounting data disks"
         _r = HTTP.request("GET", "http://169.254.169.254/metadata/instance?api-version=2021-02-01", ["Metadata"=>"true"]; redirect=false)
         r = JSON.parse(String(_r.body))
         luns = String[]
@@ -2549,7 +2566,7 @@ function mount_datadisks()
                 if lun ∈ luns
                     try
                         name = blk["name"]
-                        @info "mounting data disk with lun $lun ($name)..."
+                        @debug "mounting data disk with lun $lun ($name)..."
                         run(`sudo parted /dev/$name --script mklabel gpt mkpart xfspart xfs 0% 100%`)
                         sleep(1) # I'm not sure why this is needed, but the following command often fails without it
                         run(`sudo mkfs.xfs /dev/$(name)1`)
@@ -2557,7 +2574,7 @@ function mount_datadisks()
                         run(`sudo mkdir /scratch$lun`)
                         run(`sudo mount /dev/$(name)1 /scratch$lun`)
                         run(`sudo chmod 777 /scratch$lun`)
-                        @info "done mounting data disk with lun $lun ($name)"
+                        @debug "done mounting data disk with lun $lun ($name)"
                     catch e
                         @error "caught error formatting mounting data disk lun=$lun ($name)"
                         logerror(e, Logging.Debug)
@@ -2656,7 +2673,7 @@ function detachedservice(address=ip"0.0.0.0"; server=nothing, subscriptionid="",
 end
 
 function detachedrun(request::HTTP.Request)
-    @info "inside detachedrun"
+    @debug "inside detachedrun"
     local process, id, pid, r
 
     try
@@ -2791,7 +2808,7 @@ function detachedkill(request::HTTP.Request)
 end
 
 function detachedstatus(request::HTTP.Request)
-    @info "inside detachedstatus"
+    @debug "inside detachedstatus"
     local id
     try
         id = split(request.target, '/')[5]

--- a/test/test_validate_connections.jl
+++ b/test/test_validate_connections.jl
@@ -1,0 +1,282 @@
+using Test, Distributed, Sockets, Base64, JSON
+
+# Load AzManagers without triggering full Azure init
+using AzManagers
+
+const COOKIE = Distributed.cluster_cookie()
+const HDR_COOKIE_LEN = Distributed.HDR_COOKIE_LEN
+
+"""
+Simulate a worker connecting to the coordinator and sending the expected protocol:
+1. Write cluster cookie (HDR_COOKIE_LEN bytes)
+2. Write base64-encoded JSON connection string + newline
+"""
+function fake_worker_connect(port; delay=0.0, send_cookie=true, bad_cookie=false, send_connstr=true, ppi=1)
+    sock = connect(getipaddr(), port)
+    if delay > 0
+        sleep(delay)
+    end
+    if send_cookie
+        cookie = bad_cookie ? repeat("X", HDR_COOKIE_LEN) : COOKIE
+        write(sock, cookie)
+    end
+    if send_connstr && send_cookie && !bad_cookie
+        connstr = JSON.json(Dict(
+            "bind_addr" => string(getipaddr()),
+            "ppi" => ppi,
+            "exeflags" => "--worker",
+            "userdata" => Dict(
+                "subscriptionid" => "test-sub",
+                "resourcegroup" => "test-rg",
+                "scalesetname" => "test-ss",
+                "instanceid" => "test-$(rand(1000:9999))",
+                "priority" => "regular"
+            )
+        ))
+        write(sock, base64encode(connstr) * "\n")
+    end
+    sock
+end
+
+@testset "Connection Validation" begin
+    # Start a local TCP server (simulating the coordinator)
+    port, server = listenany(getipaddr(), 19000)
+
+    @testset "validate_connection - good socket" begin
+        # Spawn a fake worker that sends immediately
+        client_task = @async fake_worker_connect(port; delay=0.0)
+
+        sock = accept(server)
+        # Use a mock manager (we only need it for the warn path)
+        wconfig = AzManagers.validate_connection(nothing, sock)
+
+        @test wconfig !== nothing
+        @test wconfig.bind_addr == string(getipaddr())
+        @test wconfig.count == 1
+        @test wconfig.exename == "julia"
+        @test wconfig.userdata["scalesetname"] == "test-ss"
+
+        # Clean up client
+        close(fetch(client_task))
+    end
+
+    @testset "validate_connection - slow socket (2s delay)" begin
+        # Worker that delays 2s before sending — should still succeed (timeout is 30s)
+        client_task = @async fake_worker_connect(port; delay=2.0)
+
+        sock = accept(server)
+        t0 = time()
+        wconfig = AzManagers.validate_connection(nothing, sock)
+        elapsed = time() - t0
+
+        @test wconfig !== nothing
+        @test elapsed >= 1.5  # confirm it actually waited
+        @test wconfig.bind_addr == string(getipaddr())
+
+        close(fetch(client_task))
+    end
+
+    @testset "validate_connection - dead socket (never sends)" begin
+        # Worker connects but never sends anything — should timeout and return nothing
+        # Use a short timeout for testing
+        withenv("JULIA_AZMANAGERS_VALIDATION_TIMEOUT" => "2.0") do
+            client_task = @async begin
+                sock = connect(getipaddr(), port)
+                sleep(10)  # hold connection open but never send
+                sock
+            end
+
+            sock = accept(server)
+            t0 = time()
+            wconfig = AzManagers.validate_connection(nothing, sock)
+            elapsed = time() - t0
+
+            @test wconfig === nothing
+            @test elapsed >= 1.5
+            @test elapsed < 5.0  # should timeout at ~2s, not wait forever
+
+            close(fetch(client_task))
+        end
+    end
+
+    @testset "validate_connection - bad cookie" begin
+        client_task = @async fake_worker_connect(port; bad_cookie=true)
+
+        sock = accept(server)
+        wconfig = AzManagers.validate_connection(nothing, sock)
+
+        @test wconfig === nothing
+
+        close(fetch(client_task))
+    end
+
+    @testset "validate_connection - ppi > 1" begin
+        client_task = @async fake_worker_connect(port; ppi=4)
+
+        sock = accept(server)
+        wconfig = AzManagers.validate_connection(nothing, sock)
+
+        @test wconfig !== nothing
+        @test wconfig.count == 4
+
+        close(fetch(client_task))
+    end
+
+    @testset "concurrent validations (32 workers, 4 bad)" begin
+        n_good = 28
+        n_bad = 4
+        n_total = n_good + n_bad
+
+        withenv("JULIA_AZMANAGERS_VALIDATION_TIMEOUT" => "3.0") do
+            # Spawn all fake workers
+            client_tasks = []
+            for i in 1:n_good
+                push!(client_tasks, @async fake_worker_connect(port; delay=rand()*0.5))
+            end
+            for i in 1:n_bad
+                push!(client_tasks, @async begin
+                    sock = connect(getipaddr(), port)
+                    sleep(10)  # dead socket
+                    sock
+                end)
+            end
+
+            # Accept and validate all concurrently (as the real code does)
+            results = Channel{Union{Nothing, WorkerConfig}}(n_total)
+            t0 = time()
+            @sync for i in 1:n_total
+                @async begin
+                    sock = accept(server)
+                    wconfig = AzManagers.validate_connection(nothing, sock)
+                    put!(results, wconfig)
+                end
+            end
+            elapsed = time() - t0
+            close(results)
+
+            validated = filter(!isnothing, collect(results))
+
+            @test length(validated) == n_good
+            # All 32 should complete within timeout + margin, NOT 32 * timeout
+            @test elapsed < 8.0  # concurrent, not serial
+
+            # Clean up
+            for t in client_tasks
+                try close(fetch(t)) catch end
+            end
+        end
+    end
+
+    close(server)
+end
+
+@testset "Pipeline Integration" begin
+    # Test the full pipeline: accept → @async validate → pending_validated channel
+    # This mirrors add_pending_connections exactly, but with a test-local server and channel.
+
+    port, server = listenany(getipaddr(), 19100)
+    pending_validated = Channel{WorkerConfig}(64)
+
+    n_good = 16
+    n_slow = 4     # 1.5s delay — should still succeed
+    n_dead = 4     # never send — should timeout and be discarded
+    n_bad_cookie = 2
+    n_total = n_good + n_slow + n_dead + n_bad_cookie
+    n_expected = n_good + n_slow  # only good + slow should make it through
+
+    withenv("JULIA_AZMANAGERS_VALIDATION_TIMEOUT" => "3.0") do
+        # Start the accept loop — this is the real add_pending_connections logic
+        accept_task = @async begin
+            for _ in 1:n_total
+                try
+                    s = accept(server)
+                    @async try
+                        wconfig = AzManagers.validate_connection(nothing, s)
+                        if wconfig !== nothing
+                            put!(pending_validated, wconfig)
+                        end
+                    catch e
+                        @error "pipeline test: validation error" exception=(e, catch_backtrace())
+                    end
+                catch e
+                    @error "pipeline test: accept error" exception=(e, catch_backtrace())
+                end
+            end
+        end
+
+        # Fire all fake workers concurrently
+        client_tasks = Task[]
+        for i in 1:n_good
+            push!(client_tasks, @async fake_worker_connect(port; delay=rand()*0.1))
+        end
+        for i in 1:n_slow
+            push!(client_tasks, @async fake_worker_connect(port; delay=1.5))
+        end
+        for i in 1:n_dead
+            push!(client_tasks, @async begin
+                sock = connect(getipaddr(), port)
+                sleep(15)
+                sock
+            end)
+        end
+        for i in 1:n_bad_cookie
+            push!(client_tasks, @async fake_worker_connect(port; bad_cookie=true))
+        end
+
+        # Drain the channel and collect validated configs
+        validated = WorkerConfig[]
+        t0 = time()
+
+        # We expect n_expected configs. Dead sockets timeout at 3s.
+        # Use a generous deadline: timeout + margin
+        deadline = 8.0
+        while length(validated) < n_expected && (time() - t0) < deadline
+            if isready(pending_validated)
+                push!(validated, take!(pending_validated))
+            else
+                sleep(0.05)
+            end
+        end
+
+        # Wait a bit more to confirm no extras sneak through
+        sleep(0.5)
+        while isready(pending_validated)
+            push!(validated, take!(pending_validated))
+        end
+
+        elapsed = time() - t0
+
+        @testset "correct number of validated connections" begin
+            @test length(validated) == n_expected
+        end
+
+        @testset "all validated configs have expected fields" begin
+            for wc in validated
+                @test wc.bind_addr == string(getipaddr())
+                @test wc.exename == "julia"
+                @test wc.userdata["scalesetname"] == "test-ss"
+                @test wc.io isa TCPSocket
+            end
+        end
+
+        @testset "pipeline completes within bounded time (not serial)" begin
+            # If validations were serial: n_dead * 3s timeout + n_slow * 1.5s = 18s minimum
+            # Concurrent: should finish within timeout + margin ≈ 5-6s
+            @test elapsed < 8.0
+        end
+
+        @testset "dead and bad-cookie sockets were discarded" begin
+            # pending_validated should be empty — no extras
+            @test !isready(pending_validated)
+        end
+
+        # Wait for dead socket timeouts to finish, then clean up
+        wait(accept_task)
+        for t in client_tasks
+            try close(fetch(t)) catch end
+        end
+    end
+
+    close(pending_validated)
+    close(server)
+end


### PR DESCRIPTION
Move socket IO (cookie read + connection string parse) out of addprocs_locked into validate_connection(), which runs with a configurable timeout (JULIA_AZMANAGERS_VALIDATION_TIMEOUT, default 30s) before sockets enter the batch. Only validated WorkerConfig objects are batched and passed to addprocs.

**Problem**: Raw TCPSocket objects handed to addprocs_locked → launch → launch_on_machine could block on read() if a VM was slow/dead, holding worker_lock and causing other workers in the batch to time out and drop.

**Changes**:
- New validate_connection() with async timeout + _read_worker_config()
- process_pending_connections batches WorkerConfig[] instead of TCPSocket[]
- launch() pushes pre-built WorkerConfigs (no IO inside worker_lock)
- Remove launch_on_machine (logic moved to validate_connection)
- Rename sockets kwarg to wconfigs through addprocs/addprocs_with_timeout

**Benefits**:
- Dead/stale sockets filtered before entering batch
- No IO inside worker_lock (less time holding the lock)
- VMs that TCP-connect but crash before sending cookie are silently discarded

Bump version to 3.17.9