### PR TITLE
Pre-validate connections before batching

### DIFF
--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -515,13 +515,57 @@ function add_pending_connections()
     end
 end
 
-function Distributed.addprocs(manager::AzManager; sockets)
+function validate_connection(manager, socket)
+    validation_timeout = parse(Float64, get(ENV, "JULIA_AZMANAGERS_VALIDATION_TIMEOUT", "30.0"))
+    tsk = @async _read_worker_config(socket)
+
+    watchdog = Timer(validation_timeout) do _
+        if !istaskdone(tsk)
+            @async Base.throwto(tsk, InterruptException())
+        end
+    end
+
+    local wconfig
+    try
+        wconfig = fetch(tsk)
+    catch e
+        @warn "connection validation failed, discarding socket" exception=(e, catch_backtrace())
+        close(socket)
+        return nothing
+    finally
+        close(watchdog)
+    end
+
+    wconfig
+end
+
+function _read_worker_config(socket)
+    _cookie = read(socket, Distributed.HDR_COOKIE_LEN)
+    cookie = String(_cookie)
+    cookie == Distributed.cluster_cookie() || error("Invalid cookie sent by remote worker.")
+
+    _connection_string = readline(socket)
+    connection_string = String(base64decode(_connection_string))
+    vm = JSON.parse(connection_string)
+
+    wconfig = WorkerConfig()
+    wconfig.io = socket
+    wconfig.bind_addr = vm["bind_addr"]
+    wconfig.count = vm["ppi"]
+    wconfig.exename = "julia"
+    wconfig.exeflags = `$(vm["exeflags"])`
+    wconfig.userdata = vm["userdata"]
+
+    wconfig
+end
+
+function Distributed.addprocs(manager::AzManager; wconfigs)
     pids = []
     try
         Distributed.init_multi()
         Distributed.cluster_mgmt_from_master_check()
         lock(Distributed.worker_lock)
-        pids = Distributed.addprocs_locked(manager; sockets)
+        pids = Distributed.addprocs_locked(manager; wconfigs)
     catch e
         @debug "AzManagers, error processing pending connection"
         logerror(e, Logging.Debug)
@@ -531,11 +575,11 @@ function Distributed.addprocs(manager::AzManager; sockets)
     pids
 end
 
-function addprocs_with_timeout(manager; sockets)
+function addprocs_with_timeout(manager; wconfigs)
     # Distributed.setup_launched_worker also uses Distributed.worker_timeout, so we add a grace period
     # to allow for the Distributed.setup_launched_worker to hit its timeout.
     timeout = Distributed.worker_timeout() + 30
-    tsk_addprocs = @async addprocs(manager; sockets)
+    tsk_addprocs = @async addprocs(manager; wconfigs)
     tic = time()
     pids = []
     interrupted = false
@@ -566,32 +610,42 @@ end
 
 function process_pending_connections()
     manager = azmanager()
-    sockets = TCPSocket[]
+    wconfigs = WorkerConfig[]
 
-    max_sockets = manager.pending_up.sz_max
+    max_wconfigs = manager.pending_up.sz_max
     min_instances_per_second = parse(Float64, get(ENV, "JULIA_AZMANAGERS_MIN_INSTANCES_PER_MINUTE", "10")) / 60 # if we drop below N new instances per minute, then we trigger addprocs
     min_cadence = parse(Int, get(ENV, "JULIA_AZMANAGERS_PENDING_CADENCE", "60"))
     tic = time()
     while true
         try
-            if isempty(sockets)
+            local socket
+            if isempty(wconfigs)
                 @debug "taking from manager.pending_up" manager.pending_up.n_avail_items
-                push!(sockets, take!(manager.pending_up))
-                @debug "done taking from manager.pending_up" manager.pending_up.n_avail_items length(sockets)
-            elseif isready(manager.pending_up) && length(sockets) < max_sockets
+                socket = take!(manager.pending_up)
+                @debug "done taking from manager.pending_up" manager.pending_up.n_avail_items
+            elseif isready(manager.pending_up) && length(wconfigs) < max_wconfigs
                 @debug "taking from manager.pending_up" manager.pending_up.n_avail_items
-                push!(sockets, take!(manager.pending_up))
-                @debug "done taking from manager.pending_up" manager.pending_up.n_avail_items length(sockets)
+                socket = take!(manager.pending_up)
+                @debug "done taking from manager.pending_up" manager.pending_up.n_avail_items
             else
                 sleep(0.1)
+                socket = nothing
+            end
+
+            if socket !== nothing
+                wconfig = validate_connection(manager, socket)
+                if wconfig !== nothing
+                    push!(wconfigs, wconfig)
+                    @debug "validated connection added to batch" length(wconfigs)
+                end
             end
 
             elapsedtime = time() - tic
-            instances_per_second = length(sockets)/elapsedtime
-            if length(sockets) == 0 || (elapsedtime < min_cadence && instances_per_second > min_instances_per_second && length(sockets) < max_sockets)
+            instances_per_second = length(wconfigs)/elapsedtime
+            if length(wconfigs) == 0 || (elapsedtime < min_cadence && instances_per_second > min_instances_per_second && length(wconfigs) < max_wconfigs)
                 continue
             else
-                @debug "triggered adding machines" elapsedtime min_cadence instances_per_second min_instances_per_second length(sockets) max_sockets nworkers_provisioned()
+                @debug "triggered adding machines" elapsedtime min_cadence instances_per_second min_instances_per_second length(wconfigs) max_wconfigs nworkers_provisioned()
             end
         catch e
             @error "AzManagers, error retrieving pending connection"
@@ -600,9 +654,9 @@ function process_pending_connections()
         end
 
         @debug "calling addprocs_with_timeout from process_pending_connections"
-        pids = addprocs_with_timeout(manager; sockets)
+        pids = addprocs_with_timeout(manager; wconfigs)
         @debug "done calling addprocs_with_timeout from process_pending_connections"
-        empty!(sockets)
+        empty!(wconfigs)
         tic = time()
 
         @debug "starting preempt loops" pids
@@ -883,59 +937,12 @@ function Distributed.addprocs(mgr::AzManager, template::AbstractString, n::Int; 
 end
 
 function Distributed.launch(manager::AzManager, params::Dict, launched::Array, c::Condition)
-    sockets = params[:sockets]
+    wconfigs = params[:wconfigs]
 
-    @sync for socket in sockets
-        @async try
-            Distributed.launch_on_machine(manager, launched, c, socket)
-        catch e
-            @error "failed to launch on machine for socket=$socket"
-            logerror(e, Logging.Debug)
-        end
+    for wconfig in wconfigs
+        push!(launched, wconfig)
+        notify(c)
     end
-    notify(c)
-end
-
-function Distributed.launch_on_machine(manager::AzManager, launched, c, socket)
-    local _cookie
-    try
-        _cookie = read(socket, Distributed.HDR_COOKIE_LEN)
-    catch e
-        @error "unable to read cookie from socket"
-        logerror(e, Logging.Debug)
-        return
-    end
-
-    cookie = String(_cookie)
-    cookie == Distributed.cluster_cookie() || error("Invalid cookie sent by remote worker.")
-
-    local _connection_string
-    try
-        _connection_string = readline(socket)
-    catch e
-        @error "unable to read connection string from socket"
-        throw(e)
-    end
-
-    connection_string = String(base64decode(_connection_string))
-
-    local vm
-    try
-        vm = JSON.parse(connection_string)
-    catch e
-        @error "unable to parse connection string, string=$connection_string, cookie=$cookie"
-        throw(e)
-    end
-
-    wconfig = WorkerConfig()
-    wconfig.io = socket
-    wconfig.bind_addr = vm["bind_addr"]
-    wconfig.count = vm["ppi"]
-    wconfig.exename = "julia"
-    wconfig.exeflags = `$(vm["exeflags"])`
-    wconfig.userdata = vm["userdata"]
-
-    push!(launched, wconfig)
     notify(c)
 end
 

--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -188,6 +188,7 @@ mutable struct AzManager <: ClusterManager
     show_quota::Bool
     scalesets::Dict{ScaleSet,Int}
     pending_up::Channel{TCPSocket}
+    pending_validated::Channel{WorkerConfig}
     pending_down::Dict{ScaleSet,Set{String}}
     deleted::Dict{ScaleSet,Dict{String,DateTime}}
     pruned::Dict{ScaleSet,Set{String}}
@@ -221,6 +222,7 @@ function azmanager!(session, ssh_user, nretry, verbose, save_cloud_init_failures
 
     _manager.port,_manager.server = listenany(getipaddr(), 9000)
     _manager.pending_up = Channel{TCPSocket}(64)
+    _manager.pending_validated = Channel{WorkerConfig}(64)
     _manager.pending_down = Dict{ScaleSet,Set{String}}()
     _manager.deleted = Dict{ScaleSet,Dict{String,DateTime}}()
     _manager.pruned = Dict{ScaleSet,Set{String}}()
@@ -504,9 +506,17 @@ function add_pending_connections()
     while true
         try
             let s = accept(manager.server)
-                @debug "pushing new socket onto manger.pending_up" manager.pending_up.n_avail_items
-                put!(manager.pending_up, s)
-                @debug "done pushing new socket onto manger.pending_up" manager.pending_up.n_avail_items
+                @debug "accepted new socket, spawning validation"
+                @async try
+                    wconfig = validate_connection(manager, s)
+                    if wconfig !== nothing
+                        put!(manager.pending_validated, wconfig)
+                        @debug "validated connection queued" manager.pending_validated.n_avail_items
+                    end
+                catch e
+                    @error "AzManagers, error validating connection"
+                    logerror(e, Logging.Debug)
+                end
             end
         catch e
             @error "AzManagers, error adding pending connection"
@@ -612,32 +622,22 @@ function process_pending_connections()
     manager = azmanager()
     wconfigs = WorkerConfig[]
 
-    max_wconfigs = manager.pending_up.sz_max
+    max_wconfigs = manager.pending_validated.sz_max
     min_instances_per_second = parse(Float64, get(ENV, "JULIA_AZMANAGERS_MIN_INSTANCES_PER_MINUTE", "10")) / 60 # if we drop below N new instances per minute, then we trigger addprocs
     min_cadence = parse(Int, get(ENV, "JULIA_AZMANAGERS_PENDING_CADENCE", "60"))
     tic = time()
     while true
         try
-            local socket
             if isempty(wconfigs)
-                @debug "taking from manager.pending_up" manager.pending_up.n_avail_items
-                socket = take!(manager.pending_up)
-                @debug "done taking from manager.pending_up" manager.pending_up.n_avail_items
-            elseif isready(manager.pending_up) && length(wconfigs) < max_wconfigs
-                @debug "taking from manager.pending_up" manager.pending_up.n_avail_items
-                socket = take!(manager.pending_up)
-                @debug "done taking from manager.pending_up" manager.pending_up.n_avail_items
+                @debug "taking from manager.pending_validated" manager.pending_validated.n_avail_items
+                push!(wconfigs, take!(manager.pending_validated))
+                @debug "done taking from manager.pending_validated" manager.pending_validated.n_avail_items length(wconfigs)
+            elseif isready(manager.pending_validated) && length(wconfigs) < max_wconfigs
+                @debug "taking from manager.pending_validated" manager.pending_validated.n_avail_items
+                push!(wconfigs, take!(manager.pending_validated))
+                @debug "done taking from manager.pending_validated" manager.pending_validated.n_avail_items length(wconfigs)
             else
                 sleep(0.1)
-                socket = nothing
-            end
-
-            if socket !== nothing
-                wconfig = validate_connection(manager, socket)
-                if wconfig !== nothing
-                    push!(wconfigs, wconfig)
-                    @debug "validated connection added to batch" length(wconfigs)
-                end
             end
 
             elapsedtime = time() - tic

--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -539,7 +539,7 @@ function validate_connection(manager, socket)
     try
         wconfig = fetch(tsk)
     catch e
-        @warn "connection validation failed, discarding socket" exception=(e, catch_backtrace())
+        @debug "connection validation failed, discarding socket" exception=(e, catch_backtrace())
         close(socket)
         return nothing
     finally

--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -858,7 +858,7 @@ used on the Julia workers.  This feature makes use of package extensions, meanin
 that `using MPI` is somewhere in your calling script.
 [5] This may result in a re-boot of the VMs
 """
-function Distributed.addprocs(_::AzManager, template::Dict, n::Int;
+function Distributed.addprocs(::AzManager, template::Dict, n::Int;
         subscriptionid = "",
         resourcegroup = "",
         sigimagename = "",

--- a/test/test_validate_connections.jl
+++ b/test/test_validate_connections.jl
@@ -1,0 +1,282 @@
+using Test, Distributed, Sockets, Base64, JSON
+
+# Load AzManagers without triggering full Azure init
+using AzManagers
+
+const COOKIE = Distributed.cluster_cookie()
+const HDR_COOKIE_LEN = Distributed.HDR_COOKIE_LEN
+
+"""
+Simulate a worker connecting to the coordinator and sending the expected protocol:
+1. Write cluster cookie (HDR_COOKIE_LEN bytes)
+2. Write base64-encoded JSON connection string + newline
+"""
+function fake_worker_connect(port; delay=0.0, send_cookie=true, bad_cookie=false, send_connstr=true, ppi=1)
+    sock = connect(getipaddr(), port)
+    if delay > 0
+        sleep(delay)
+    end
+    if send_cookie
+        cookie = bad_cookie ? repeat("X", HDR_COOKIE_LEN) : COOKIE
+        write(sock, cookie)
+    end
+    if send_connstr && send_cookie && !bad_cookie
+        connstr = JSON.json(Dict(
+            "bind_addr" => string(getipaddr()),
+            "ppi" => ppi,
+            "exeflags" => "--worker",
+            "userdata" => Dict(
+                "subscriptionid" => "test-sub",
+                "resourcegroup" => "test-rg",
+                "scalesetname" => "test-ss",
+                "instanceid" => "test-$(rand(1000:9999))",
+                "priority" => "regular"
+            )
+        ))
+        write(sock, base64encode(connstr) * "\n")
+    end
+    sock
+end
+
+@testset "Connection Validation" begin
+    # Start a local TCP server (simulating the coordinator)
+    port, server = listenany(getipaddr(), 19000)
+
+    @testset "validate_connection - good socket" begin
+        # Spawn a fake worker that sends immediately
+        client_task = @async fake_worker_connect(port; delay=0.0)
+
+        sock = accept(server)
+        # Use a mock manager (we only need it for the warn path)
+        wconfig = AzManagers.validate_connection(nothing, sock)
+
+        @test wconfig !== nothing
+        @test wconfig.bind_addr == string(getipaddr())
+        @test wconfig.count == 1
+        @test wconfig.exename == "julia"
+        @test wconfig.userdata["scalesetname"] == "test-ss"
+
+        # Clean up client
+        close(fetch(client_task))
+    end
+
+    @testset "validate_connection - slow socket (2s delay)" begin
+        # Worker that delays 2s before sending — should still succeed (timeout is 30s)
+        client_task = @async fake_worker_connect(port; delay=2.0)
+
+        sock = accept(server)
+        t0 = time()
+        wconfig = AzManagers.validate_connection(nothing, sock)
+        elapsed = time() - t0
+
+        @test wconfig !== nothing
+        @test elapsed >= 1.5  # confirm it actually waited
+        @test wconfig.bind_addr == string(getipaddr())
+
+        close(fetch(client_task))
+    end
+
+    @testset "validate_connection - dead socket (never sends)" begin
+        # Worker connects but never sends anything — should timeout and return nothing
+        # Use a short timeout for testing
+        withenv("JULIA_AZMANAGERS_VALIDATION_TIMEOUT" => "2.0") do
+            client_task = @async begin
+                sock = connect(getipaddr(), port)
+                sleep(10)  # hold connection open but never send
+                sock
+            end
+
+            sock = accept(server)
+            t0 = time()
+            wconfig = AzManagers.validate_connection(nothing, sock)
+            elapsed = time() - t0
+
+            @test wconfig === nothing
+            @test elapsed >= 1.5
+            @test elapsed < 5.0  # should timeout at ~2s, not wait forever
+
+            close(fetch(client_task))
+        end
+    end
+
+    @testset "validate_connection - bad cookie" begin
+        client_task = @async fake_worker_connect(port; bad_cookie=true)
+
+        sock = accept(server)
+        wconfig = AzManagers.validate_connection(nothing, sock)
+
+        @test wconfig === nothing
+
+        close(fetch(client_task))
+    end
+
+    @testset "validate_connection - ppi > 1" begin
+        client_task = @async fake_worker_connect(port; ppi=4)
+
+        sock = accept(server)
+        wconfig = AzManagers.validate_connection(nothing, sock)
+
+        @test wconfig !== nothing
+        @test wconfig.count == 4
+
+        close(fetch(client_task))
+    end
+
+    @testset "concurrent validations (32 workers, 4 bad)" begin
+        n_good = 28
+        n_bad = 4
+        n_total = n_good + n_bad
+
+        withenv("JULIA_AZMANAGERS_VALIDATION_TIMEOUT" => "3.0") do
+            # Spawn all fake workers
+            client_tasks = []
+            for i in 1:n_good
+                push!(client_tasks, @async fake_worker_connect(port; delay=rand()*0.5))
+            end
+            for i in 1:n_bad
+                push!(client_tasks, @async begin
+                    sock = connect(getipaddr(), port)
+                    sleep(10)  # dead socket
+                    sock
+                end)
+            end
+
+            # Accept and validate all concurrently (as the real code does)
+            results = Channel{Union{Nothing, WorkerConfig}}(n_total)
+            t0 = time()
+            @sync for i in 1:n_total
+                @async begin
+                    sock = accept(server)
+                    wconfig = AzManagers.validate_connection(nothing, sock)
+                    put!(results, wconfig)
+                end
+            end
+            elapsed = time() - t0
+            close(results)
+
+            validated = filter(!isnothing, collect(results))
+
+            @test length(validated) == n_good
+            # All 32 should complete within timeout + margin, NOT 32 * timeout
+            @test elapsed < 8.0  # concurrent, not serial
+
+            # Clean up
+            for t in client_tasks
+                try close(fetch(t)) catch end
+            end
+        end
+    end
+
+    close(server)
+end
+
+@testset "Pipeline Integration" begin
+    # Test the full pipeline: accept → @async validate → pending_validated channel
+    # This mirrors add_pending_connections exactly, but with a test-local server and channel.
+
+    port, server = listenany(getipaddr(), 19100)
+    pending_validated = Channel{WorkerConfig}(64)
+
+    n_good = 16
+    n_slow = 4     # 1.5s delay — should still succeed
+    n_dead = 4     # never send — should timeout and be discarded
+    n_bad_cookie = 2
+    n_total = n_good + n_slow + n_dead + n_bad_cookie
+    n_expected = n_good + n_slow  # only good + slow should make it through
+
+    withenv("JULIA_AZMANAGERS_VALIDATION_TIMEOUT" => "3.0") do
+        # Start the accept loop — this is the real add_pending_connections logic
+        accept_task = @async begin
+            for _ in 1:n_total
+                try
+                    s = accept(server)
+                    @async try
+                        wconfig = AzManagers.validate_connection(nothing, s)
+                        if wconfig !== nothing
+                            put!(pending_validated, wconfig)
+                        end
+                    catch e
+                        @error "pipeline test: validation error" exception=(e, catch_backtrace())
+                    end
+                catch e
+                    @error "pipeline test: accept error" exception=(e, catch_backtrace())
+                end
+            end
+        end
+
+        # Fire all fake workers concurrently
+        client_tasks = Task[]
+        for i in 1:n_good
+            push!(client_tasks, @async fake_worker_connect(port; delay=rand()*0.1))
+        end
+        for i in 1:n_slow
+            push!(client_tasks, @async fake_worker_connect(port; delay=1.5))
+        end
+        for i in 1:n_dead
+            push!(client_tasks, @async begin
+                sock = connect(getipaddr(), port)
+                sleep(15)
+                sock
+            end)
+        end
+        for i in 1:n_bad_cookie
+            push!(client_tasks, @async fake_worker_connect(port; bad_cookie=true))
+        end
+
+        # Drain the channel and collect validated configs
+        validated = WorkerConfig[]
+        t0 = time()
+
+        # We expect n_expected configs. Dead sockets timeout at 3s.
+        # Use a generous deadline: timeout + margin
+        deadline = 8.0
+        while length(validated) < n_expected && (time() - t0) < deadline
+            if isready(pending_validated)
+                push!(validated, take!(pending_validated))
+            else
+                sleep(0.05)
+            end
+        end
+
+        # Wait a bit more to confirm no extras sneak through
+        sleep(0.5)
+        while isready(pending_validated)
+            push!(validated, take!(pending_validated))
+        end
+
+        elapsed = time() - t0
+
+        @testset "correct number of validated connections" begin
+            @test length(validated) == n_expected
+        end
+
+        @testset "all validated configs have expected fields" begin
+            for wc in validated
+                @test wc.bind_addr == string(getipaddr())
+                @test wc.exename == "julia"
+                @test wc.userdata["scalesetname"] == "test-ss"
+                @test wc.io isa TCPSocket
+            end
+        end
+
+        @testset "pipeline completes within bounded time (not serial)" begin
+            # If validations were serial: n_dead * 3s timeout + n_slow * 1.5s = 18s minimum
+            # Concurrent: should finish within timeout + margin ≈ 5-6s
+            @test elapsed < 8.0
+        end
+
+        @testset "dead and bad-cookie sockets were discarded" begin
+            # pending_validated should be empty — no extras
+            @test !isready(pending_validated)
+        end
+
+        # Wait for dead socket timeouts to finish, then clean up
+        wait(accept_task)
+        for t in client_tasks
+            try close(fetch(t)) catch end
+        end
+    end
+
+    close(pending_validated)
+    close(server)
+end


### PR DESCRIPTION
Move socket IO (cookie read + connection string parse) out of addprocs_locked into validate_connection(), which runs with a configurable timeout (JULIA_AZMANAGERS_VALIDATION_TIMEOUT, default 30s) before sockets enter the batch. Only validated WorkerConfig objects are batched and passed to addprocs.

**Problem**: Raw TCPSocket objects handed to addprocs_locked → launch → launch_on_machine could block on read() if a VM was slow/dead, holding worker_lock and causing other workers in the batch to time out and drop.

**Changes**:
- New validate_connection() with async timeout + _read_worker_config()
- process_pending_connections batches WorkerConfig[] instead of TCPSocket[]
- launch() pushes pre-built WorkerConfigs (no IO inside worker_lock)
- Remove launch_on_machine (logic moved to validate_connection)
- Rename sockets kwarg to wconfigs through addprocs/addprocs_with_timeout

Cherry-picked from hotfix/prevalidate-connections (release-3 hotfix).