### PR TITLE
fix unlock in scaleset_sync method

### DIFF
--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -361,8 +361,9 @@ function scaleset_sync()
     catch e
         @error "scaleset syncing error"
         logerror(e, Logging.Debug)
+    finally
+        unlock(manager.lock)
     end
-    unlock(manager.lock)
 end
 
 function prune_cluster()


### PR DESCRIPTION
The unlock was in the wrong scope which could lead to `manager.lock` never unlocking.