### PR TITLE
Revert "fix nworkers_provisioned to account for workers pending removal"

### DIFF
--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -1083,10 +1083,7 @@ function nworkers_provisioned(service=false)
             n += N
         end
     end
-
-    _pending_down = pending_down(manager)
-    pending_down_count = isempty(_pending_down) ? 0 : mapreduce(length, +, values(_pending_down))
-    max(0, n - pending_down_count)
+    n
 end
 
 """


### PR DESCRIPTION
This reverts commit 603971291c6cc5e60621811b2b7c7dbf7ff522af.  This was a good idea but can lead to run-a-way scaleset sizes.