### PR TITLE
support JSON >= 1

### DIFF
--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -450,7 +450,7 @@ function prune_scalesets()
     instanceids = Dict{ScaleSet,Array{String}}()
     for wrkr in values(Distributed.map_pid_wrkr)
         if isdefined(wrkr, :id) && isdefined(wrkr, :config) && isa(wrkr, Distributed.Worker)
-            if isdefined(wrkr.config, :userdata) && isa(wrkr.config.userdata, Dict)
+            if isdefined(wrkr.config, :userdata) && isa(wrkr.config.userdata, AbstractDict)
                 userdata = wrkr.config.userdata
                 if haskey(userdata, "instanceid") && haskey(userdata, "scalesetname") && haskey(userdata, "resourcegroup") && haskey(userdata, "subscriptionid")
                     ss = ScaleSet(userdata["subscriptionid"], userdata["resourcegroup"], userdata["scalesetname"])


### PR DESCRIPTION
with JSON >= 1, JSON.parse output a JSON.Object rather than a Dict.  But a JSON.Object is a subtype of AbstractDict. So, this change should support both JSON < 1 and JSON >=1.