### PR TITLE
Bypass atexit hooks

### DIFF
--- a/src/AzManagers.jl
+++ b/src/AzManagers.jl
@@ -1001,7 +1001,10 @@ function Distributed.kill(manager::AzManager, id::Int, config::WorkerConfig)
     end
 
     try
-        remote_do(exit, id, 42)
+        remote_do(id) do
+            # this by-passes any the at-exit hook to ensure that the process on the worker exits without delay.
+            ccall(:_exit, Union{}, (Int32,), 42)
+        end
     catch
     end
     @debug "kill, done remote_do"


### PR DESCRIPTION
Ensure a speedy shutdown of workers when `kill` is called.  This is similar to what is in #225.  However, #225 calls the :jl_exit c method which, in turn, still calls the at-exit hook.  So, I'm assuming the contents of this PR is what was intended.